### PR TITLE
(#1) feat: initialize ai-heatmap project

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy AI Heatmap
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "public/data.json"
+      - "src/**"
+      - "index.html"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm ci
+
+      - name: Generate static SVG from data.json
+        run: npm run generate:svg
+
+      - run: npm run build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.omc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,208 @@
+# AI Heatmap
+
+GitHub-style heatmap for your AI usage costs. Powered by [ccusage](https://github.com/ryoppippi/ccusage) + [react-activity-calendar](https://github.com/grubersjoe/react-activity-calendar).
+
+## Preview
+
+<!-- Replace YOUR_VERCEL_DOMAIN with your actual Vercel deployment URL -->
+![AI Heatmap](https://YOUR_VERCEL_DOMAIN/api/heatmap)
+
+### Variations
+
+```markdown
+<!-- Dark mode with full stats -->
+![](https://YOUR_VERCEL_DOMAIN/api/heatmap?colorScheme=dark)
+
+<!-- Blue theme, heatmap + stats only -->
+![](https://YOUR_VERCEL_DOMAIN/api/heatmap?theme=blue&weekday=false)
+
+<!-- Heatmap only (clean embed) -->
+![](https://YOUR_VERCEL_DOMAIN/api/heatmap?stats=false&weekday=false)
+
+<!-- Custom date range -->
+![](https://YOUR_VERCEL_DOMAIN/api/heatmap?start=2026-01-01&end=2026-02-18)
+```
+
+## Quick Start
+
+```bash
+# Generate data from local ccusage logs
+npx ai-heatmap generate
+
+# Init a new GitHub Pages repo
+npx ai-heatmap init my-ai-heatmap
+
+# Push data to repo
+npx ai-heatmap push --repo owner/my-ai-heatmap
+
+# Generate + push in one step
+npx ai-heatmap update --repo owner/my-ai-heatmap
+```
+
+## SVG API (Vercel)
+
+Deploy this repo to Vercel for a dynamic SVG endpoint. Embed it in any README:
+
+```markdown
+![AI Heatmap](https://your-app.vercel.app/api/heatmap)
+```
+
+The SVG is generated on each request from `public/data.json`, so you can control the output with query parameters.
+
+### SVG API Options
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `colorScheme` | `light` | Color scheme: `light`, `dark` |
+| `theme` | same as `colorScheme` | Theme override: `light`, `dark`, `blue`, `orange`, `pink` |
+| `blockSize` | `16` | Size of each day block in pixels |
+| `blockMargin` | `4` | Gap between blocks in pixels |
+| `blockRadius` | `3` | Border radius of blocks in pixels |
+| `bg` | auto | Background color (e.g. `%23ffffff`). Auto: transparent (light) / `#0d1117` (dark) |
+| `textColor` | auto | Text color. Auto: `#24292f` (light) / `#c9d1d9` (dark) |
+| `start` | - | Filter start date (`YYYY-MM-DD`) |
+| `end` | - | Filter end date (`YYYY-MM-DD`) |
+| `stats` | `true` | Show stats section (daily avg, weekly avg, peak, active days) |
+| `weekday` | `true` | Show average-by-weekday bar chart |
+
+### SVG API Examples
+
+```
+# Default light theme with all sections
+/api/heatmap
+
+# Dark theme
+/api/heatmap?colorScheme=dark
+
+# Pink theme, heatmap only
+/api/heatmap?theme=pink&stats=false&weekday=false
+
+# Custom block size
+/api/heatmap?blockSize=12&blockMargin=3&blockRadius=2
+
+# Date range filter
+/api/heatmap?start=2026-01-01&end=2026-02-18
+```
+
+## GitHub Pages (Interactive)
+
+The interactive version with tooltips is deployed via GitHub Pages. Tooltips show cost, tokens, cache hit rate, and per-model breakdown.
+
+### GitHub Pages Options
+
+All options are controlled via query string:
+
+```
+https://owner.github.io/my-ai-heatmap/?colorScheme=dark&blockSize=14
+```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `colorScheme` | `light` | Color scheme: `light`, `dark` |
+| `blockSize` | `12` | Size of each day block in pixels |
+| `blockMargin` | `3` | Gap between blocks in pixels |
+| `blockRadius` | `2` | Border radius of blocks in pixels |
+| `fontSize` | `12` | Font size in pixels |
+| `hideColorLegend` | `false` | Hide the color legend |
+| `hideMonthLabels` | `false` | Hide month labels |
+| `hideTotalCount` | `false` | Hide total count label |
+| `showWeekdayLabels` | `true` | Show weekday labels (Mon, Wed, Fri) |
+| `weekStart` | `0` | First day of week (0 = Sunday, 1 = Monday) |
+| `start` | - | Filter start date (`YYYY-MM-DD`) |
+| `end` | - | Filter end date (`YYYY-MM-DD`) |
+
+### Available Themes (SVG API)
+
+| Theme | Colors |
+|-------|--------|
+| `light` | `#ebedf0` `#c6e48b` `#7bc96f` `#239a3b` `#196127` |
+| `dark` | `#161b22` `#0e4429` `#006d32` `#26a641` `#39d353` |
+| `blue` | `#ebedf0` `#c0ddf9` `#73b3f3` `#3886e1` `#1b4f91` |
+| `orange` | `#ebedf0` `#ffdf80` `#ffa742` `#e87d2f` `#ac5219` |
+| `pink` | `#ebedf0` `#ffc0cb` `#ff69b4` `#ff1493` `#c71585` |
+
+## Configuration
+
+Customize the static SVG output by editing `heatmap.config.json` in the project root:
+
+```json
+{
+  "colorScheme": "light",
+  "theme": "",
+  "blockSize": 16,
+  "blockMargin": 4,
+  "blockRadius": 3,
+  "bg": "",
+  "textColor": "",
+  "start": "",
+  "end": "",
+  "stats": true,
+  "weekday": true
+}
+```
+
+This config is used by `npm run generate:svg` to build `public/heatmap.svg`. Empty strings (`""`) use auto defaults.
+
+For the Vercel dynamic API, use query parameters instead (they override config).
+
+## Data Update
+
+`ccusage` reads Claude Code usage logs from your **local machine**, so data must be generated locally and pushed to the repo.
+
+```bash
+# Generate + push in one step
+npx ai-heatmap update --repo owner/my-ai-heatmap
+
+# Or manually
+npx ai-heatmap generate
+git add public/data.json && git commit -m "update data" && git push
+```
+
+For automated updates, use a local cron job or macOS LaunchAgent:
+
+```bash
+# crontab -e (runs daily at midnight)
+0 0 * * * cd /path/to/ai-heatmap && npx ai-heatmap update --repo owner/my-ai-heatmap
+```
+
+## Deployment
+
+### GitHub Pages
+
+1. Enable GitHub Pages (Settings > Pages > Source: GitHub Actions)
+2. Push `data.json` to `main` to trigger the first deploy
+3. Manual deploy: Actions tab > "Deploy AI Heatmap" > "Run workflow"
+
+### Vercel
+
+1. Import this repo on [vercel.com](https://vercel.com)
+2. Deploy (zero config — `vercel.json` included)
+3. Use the deployed URL for dynamic SVG embeds
+
+## Local Development
+
+```bash
+npm install
+npm run generate              # Generate data.json from ccusage
+npm run dev                   # Vite dev server (interactive heatmap)
+node scripts/serve-svg.mjs    # Local SVG API on :3333
+```
+
+## Project Structure
+
+```
+ai-heatmap/
+  api/heatmap.ts              # Vercel serverless SVG endpoint
+  bin/cli.mjs                 # CLI entrypoint
+  bin/init.mjs                # Repo scaffolding
+  bin/push.mjs                # Push data to GitHub
+  scripts/generate.mjs        # ccusage -> data.json
+  scripts/generate-svg.mjs    # data.json -> static heatmap.svg
+  scripts/serve-svg.mjs       # Local SVG dev server
+  src/App.tsx                 # React interactive heatmap
+  public/data.json            # Generated activity data
+```
+
+## License
+
+MIT

--- a/api/heatmap.ts
+++ b/api/heatmap.ts
@@ -1,0 +1,200 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface Activity {
+  date: string;
+  count: number;
+  level: number;
+}
+
+const THEMES: Record<string, string[]> = {
+  light: ["#ebedf0", "#c6e48b", "#7bc96f", "#239a3b", "#196127"],
+  dark: ["#161b22", "#0e4429", "#006d32", "#26a641", "#39d353"],
+  blue: ["#ebedf0", "#c0ddf9", "#73b3f3", "#3886e1", "#1b4f91"],
+  orange: ["#ebedf0", "#ffdf80", "#ffa742", "#e87d2f", "#ac5219"],
+  pink: ["#ebedf0", "#ffc0cb", "#ff69b4", "#ff1493", "#c71585"],
+};
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function num(v: string | string[] | undefined, def: number): number {
+  if (v == null || v === "") return def;
+  const n = Number(v);
+  return isNaN(n) ? def : n;
+}
+
+function usd(n: number): string {
+  return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  const {
+    colorScheme = "light",
+    blockSize: bs,
+    blockMargin: bm,
+    blockRadius: br,
+    start,
+    end,
+    theme: themeName,
+    bg,
+    textColor,
+    stats: statsParam,
+    weekday: weekdayParam,
+  } = req.query;
+
+  const BLOCK = num(bs as string, 16);
+  const GAP = num(bm as string, 4);
+  const RADIUS = num(br as string, 3);
+  const PAD = 16;
+  const LABEL_W = 36;
+  const HEADER_H = 24;
+
+  const scheme = (colorScheme as string) || "light";
+  const colors = THEMES[(themeName as string) || scheme] || THEMES.light;
+  const bgColor = (bg as string) || (scheme === "dark" ? "#0d1117" : "transparent");
+  const txtColor = (textColor as string) || (scheme === "dark" ? "#c9d1d9" : "#24292f");
+  const subColor = scheme === "dark" ? "#8b949e" : "#666";
+
+  // Load data
+  let data: Activity[];
+  try {
+    const raw = readFileSync(resolve(process.cwd(), "public/data.json"), "utf-8");
+    data = JSON.parse(raw);
+  } catch {
+    res.setHeader("Content-Type", "image/svg+xml");
+    res.status(500).send(`<svg xmlns="http://www.w3.org/2000/svg" width="400" height="40"><text x="10" y="25" fill="red">data.json not found</text></svg>`);
+    return;
+  }
+
+  // Filter by date range
+  if (start) data = data.filter((d) => d.date >= (start as string));
+  if (end) data = data.filter((d) => d.date <= (end as string));
+
+  // Group by weeks
+  const weeks: Activity[][] = [];
+  let currentWeek: Activity[] = [];
+  for (const d of data) {
+    const dow = new Date(d.date).getDay();
+    if (dow === 0 && currentWeek.length > 0) {
+      weeks.push(currentWeek);
+      currentWeek = [];
+    }
+    currentWeek.push(d);
+  }
+  if (currentWeek.length) weeks.push(currentWeek);
+
+  const cols = weeks.length;
+  const svgW = PAD * 2 + LABEL_W + cols * (BLOCK + GAP) + GAP;
+  const svgH = PAD * 2 + HEADER_H + 7 * (BLOCK + GAP) + GAP + 36;
+
+  // Month labels
+  const monthLabels: { x: number; label: string }[] = [];
+  let prevMonth = -1;
+  for (let w = 0; w < weeks.length; w++) {
+    const month = new Date(weeks[w][0].date).getMonth();
+    if (month !== prevMonth) {
+      monthLabels.push({ x: PAD + LABEL_W + w * (BLOCK + GAP), label: MONTHS[month] });
+      prevMonth = month;
+    }
+  }
+
+  // Rects
+  const rects: string[] = [];
+  for (let w = 0; w < weeks.length; w++) {
+    for (const d of weeks[w]) {
+      const dow = new Date(d.date).getDay();
+      const x = PAD + LABEL_W + w * (BLOCK + GAP);
+      const y = PAD + HEADER_H + dow * (BLOCK + GAP);
+      const color = colors[d.level] || colors[0];
+      const cost = d.count > 0 ? `$${d.count.toFixed(2)}` : "No data";
+      rects.push(`<rect x="${x}" y="${y}" width="${BLOCK}" height="${BLOCK}" rx="${RADIUS}" fill="${color}"><title>${d.date}: ${cost}</title></rect>`);
+    }
+  }
+
+  // Legend
+  const legendX = svgW - PAD - 5 * (BLOCK + GAP) - 60;
+  const legendY = PAD + HEADER_H + 7 * (BLOCK + GAP) + 10;
+  const legendRects = colors
+    .map((c, i) => `<rect x="${legendX + 40 + i * (BLOCK + GAP)}" y="${legendY}" width="${BLOCK}" height="${BLOCK}" rx="${RADIUS}" fill="${c}"/>`)
+    .join("\n");
+
+  // Total
+  const totalCost = data.reduce((s, d) => s + d.count, 0);
+  const totalFormatted = usd(totalCost);
+  const firstYear = data[0]?.date.slice(0, 4);
+  const lastYear = data[data.length - 1]?.date.slice(0, 4);
+  const yearLabel = firstYear === lastYear ? firstYear : `${firstYear}~${lastYear}`;
+
+  // Stats
+  const showStats = (statsParam as string) !== "false";
+  const showWeekday = (weekdayParam as string) !== "false";
+  const activeDays = data.filter((d) => d.count > 0);
+  const dailyAvg = activeDays.length ? totalCost / activeDays.length : 0;
+  const peak = activeDays.reduce((max, d) => (d.count > max.count ? d : max), { count: 0, date: "-" });
+
+  // Weekday averages
+  const weekdayTotals = Array(7).fill(0);
+  const weekdayCounts = Array(7).fill(0);
+  for (const d of data) {
+    if (d.count > 0) {
+      const dow = new Date(d.date).getDay();
+      weekdayTotals[dow] += d.count;
+      weekdayCounts[dow]++;
+    }
+  }
+  const weekdayAvgs = weekdayTotals.map((t: number, i: number) => (weekdayCounts[i] ? t / weekdayCounts[i] : 0));
+  const maxWeekdayAvg = Math.max(...weekdayAvgs);
+
+  // Weekly averages
+  const weeklyTotals = weeks.map((w) => w.reduce((s, d) => s + d.count, 0));
+  const activeWeeks = weeklyTotals.filter((t) => t > 0);
+  const weeklyAvg = activeWeeks.length ? activeWeeks.reduce((s, t) => s + t, 0) / activeWeeks.length : 0;
+
+  // Extra height
+  const STATS_H = showStats ? 50 : 0;
+  const WEEKDAY_H = showWeekday ? 180 : 0;
+  const totalH = svgH + STATS_H + WEEKDAY_H;
+
+  // Stats section Y
+  const statsY = legendY + BLOCK + 20;
+  const weekdayY = statsY + (showStats ? 50 : 10);
+  const BAR_W = Math.min(300, svgW - PAD * 2 - 100);
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${svgW}" height="${totalH}" viewBox="0 0 ${svgW} ${totalH}">
+<rect width="100%" height="100%" fill="${bgColor}" rx="6"/>
+<style>text{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;fill:${txtColor}}.month{font-size:10px}.day{font-size:10px}.legend-label{font-size:10px;fill:${subColor}}.total{font-size:11px;font-weight:600}.stat{font-size:11px;fill:${subColor}}.stat-val{font-size:11px;font-weight:600;fill:${txtColor}}.bar-label{font-size:11px;fill:${subColor}}.bar-val{font-size:10px;fill:${subColor}}.section-title{font-size:12px;font-weight:600}</style>
+${monthLabels.map((m) => `<text x="${m.x}" y="${PAD + 14}" class="month">${m.label}</text>`).join("\n")}
+<text x="${PAD}" y="${PAD + HEADER_H + 1 * (BLOCK + GAP) + BLOCK - 2}" class="day">Mon</text>
+<text x="${PAD}" y="${PAD + HEADER_H + 3 * (BLOCK + GAP) + BLOCK - 2}" class="day">Wed</text>
+<text x="${PAD}" y="${PAD + HEADER_H + 5 * (BLOCK + GAP) + BLOCK - 2}" class="day">Fri</text>
+${rects.join("\n")}
+<text x="${legendX}" y="${legendY + BLOCK - 1}" class="legend-label">Less</text>
+${legendRects}
+<text x="${legendX + 40 + 5 * (BLOCK + GAP)}" y="${legendY + BLOCK - 1}" class="legend-label">More</text>
+<text x="${PAD + LABEL_W}" y="${legendY + BLOCK - 1}" class="total">${totalFormatted} total (${yearLabel})</text>
+${showStats ? `
+<line x1="${PAD}" y1="${statsY - 6}" x2="${svgW - PAD}" y2="${statsY - 6}" stroke="${scheme === "dark" ? "#30363d" : "#d0d7de"}" stroke-width="1"/>
+<text x="${PAD}" y="${statsY + 12}" class="stat">Daily avg: <tspan class="stat-val">${usd(dailyAvg)}</tspan></text>
+<text x="${PAD + 200}" y="${statsY + 12}" class="stat">Weekly avg: <tspan class="stat-val">${usd(weeklyAvg)}</tspan></text>
+<text x="${PAD}" y="${statsY + 30}" class="stat">Peak: <tspan class="stat-val">${usd(peak.count)}</tspan> (${peak.date})</text>
+<text x="${PAD + 200}" y="${statsY + 30}" class="stat">Active: <tspan class="stat-val">${activeDays.length}</tspan> / ${data.length} days</text>
+` : ""}
+${showWeekday ? `
+<text x="${PAD}" y="${weekdayY}" class="section-title">Avg by weekday</text>
+${DAY_NAMES.map((name, i) => {
+  const barY = weekdayY + 14 + i * 22;
+  const barLen = maxWeekdayAvg > 0 ? (weekdayAvgs[i] / maxWeekdayAvg) * BAR_W : 0;
+  const barColor = colors[Math.min(4, Math.ceil((weekdayAvgs[i] / (maxWeekdayAvg || 1)) * 4))];
+  return `<text x="${PAD}" y="${barY + 12}" class="bar-label">${name}</text>` +
+    `<rect x="${PAD + 36}" y="${barY + 2}" width="${barLen}" height="14" rx="3" fill="${barColor}" opacity="0.85"/>` +
+    `<text x="${PAD + 42 + barLen}" y="${barY + 13}" class="bar-val">${usd(weekdayAvgs[i])}</text>`;
+}).join("\n")}
+` : ""}
+</svg>`;
+
+  res.setHeader("Content-Type", "image/svg+xml");
+  res.setHeader("Cache-Control", "public, max-age=3600, s-maxage=3600");
+  res.status(200).send(svg);
+}

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+const [command, ...args] = process.argv.slice(2);
+
+const HELP = `
+ai-heatmap - AI usage cost heatmap
+
+Commands:
+  init [repo-name]        Create a new heatmap GitHub Pages repo
+  generate [options]      Generate data.json from ccusage
+  push --repo <owner/repo>  Push data.json to target repo
+  update --repo <owner/repo>  generate + push combined
+
+Generate options:
+  --since YYYYMMDD        Start date
+  --until YYYYMMDD        End date
+
+Examples:
+  npx ai-heatmap init my-ai-heatmap
+  npx ai-heatmap generate --since 20260101
+  npx ai-heatmap push --repo seunggabi/my-ai-heatmap
+  npx ai-heatmap update --repo seunggabi/my-ai-heatmap
+`;
+
+switch (command) {
+  case "init": {
+    const script = resolve(__dirname, "init.mjs");
+    execSync(`node ${script} ${args.join(" ")}`, { stdio: "inherit" });
+    break;
+  }
+  case "generate": {
+    const script = resolve(root, "scripts/generate.mjs");
+    execSync(`node ${script} ${args.join(" ")}`, { stdio: "inherit" });
+    break;
+  }
+  case "push": {
+    const script = resolve(__dirname, "push.mjs");
+    execSync(`node ${script} ${args.join(" ")}`, { stdio: "inherit" });
+    break;
+  }
+  case "update": {
+    const genScript = resolve(root, "scripts/generate.mjs");
+    const pushScript = resolve(__dirname, "push.mjs");
+    const genArgs = args.filter(
+      (a) => a.startsWith("--since") || a.startsWith("--until"),
+    );
+    const pushArgs = args.filter((a) => a.startsWith("--repo"));
+    execSync(`node ${genScript} ${genArgs.join(" ")}`, { stdio: "inherit" });
+    execSync(`node ${pushScript} ${pushArgs.join(" ")}`, { stdio: "inherit" });
+    break;
+  }
+  default:
+    console.log(HELP);
+}

--- a/bin/push.mjs
+++ b/bin/push.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+const args = process.argv.slice(2);
+const repoIdx = args.indexOf("--repo");
+const repo = repoIdx !== -1 ? args[repoIdx + 1] : null;
+
+if (!repo) {
+  console.error("Usage: ai-heatmap push --repo <owner/repo>");
+  console.error("Example: ai-heatmap push --repo seunggabi/my-ai-heatmap");
+  process.exit(1);
+}
+
+const dataPath = resolve(root, "public/data.json");
+if (!existsSync(dataPath)) {
+  console.error("data.json not found. Run 'ai-heatmap generate' first.");
+  process.exit(1);
+}
+
+const content = readFileSync(dataPath, "utf-8");
+const base64 = Buffer.from(content).toString("base64");
+
+console.log(`Pushing data.json to ${repo}...`);
+
+// Get current file SHA if it exists (needed for update)
+let sha = "";
+try {
+  sha = execSync(
+    `gh api repos/${repo}/contents/public/data.json --jq .sha 2>/dev/null`,
+    { encoding: "utf-8" },
+  ).trim();
+} catch {
+  // File doesn't exist yet, that's fine
+}
+
+const payload = {
+  message: `Update heatmap data (${new Date().toISOString().slice(0, 10)})`,
+  content: base64,
+};
+if (sha) payload.sha = sha;
+
+const payloadStr = JSON.stringify(JSON.stringify(payload));
+
+try {
+  execSync(
+    `echo ${payloadStr} | gh api repos/${repo}/contents/public/data.json -X PUT --input -`,
+    { stdio: ["pipe", "inherit", "inherit"] },
+  );
+  console.log(`Updated public/data.json in ${repo}`);
+} catch (e) {
+  console.error("Push failed. Check gh auth and repo permissions.");
+  process.exit(1);
+}

--- a/ccusage-integration/README.md
+++ b/ccusage-integration/README.md
@@ -1,0 +1,33 @@
+# ccusage Integration: ai-heatmap
+
+This directory contains the proposed integration code for [ccusage](https://github.com/ryoppippi/ccusage).
+
+## Proposal
+
+Add `--heatmap` flag to ccusage that auto-generates and pushes data to a user's ai-heatmap GitHub Pages repo.
+
+### Usage
+
+```bash
+# One-time setup: create your heatmap repo
+npx ai-heatmap init my-ai-heatmap
+
+# Then with ccusage:
+npx ccusage daily --heatmap --heatmap-repo seunggabi/my-ai-heatmap
+
+# Or set env var for convenience:
+export CCUSAGE_HEATMAP_REPO=seunggabi/my-ai-heatmap
+npx ccusage daily --heatmap
+```
+
+### How it works
+
+1. ccusage runs its normal `daily` aggregation
+2. With `--heatmap`, it transforms the data to `react-activity-calendar` format
+3. Pushes `data.json` to the specified GitHub repo via GitHub API (`gh` CLI)
+4. GitHub Actions on the target repo auto-deploys to GitHub Pages
+
+### Files
+
+- `heatmap-plugin.mjs` — The integration module for ccusage
+- `README.md` — This file

--- a/ccusage-integration/heatmap-plugin.mjs
+++ b/ccusage-integration/heatmap-plugin.mjs
@@ -1,0 +1,93 @@
+/**
+ * ai-heatmap plugin for ccusage
+ *
+ * Transforms ccusage daily data → react-activity-calendar format
+ * and pushes to a GitHub repo for GitHub Pages deployment.
+ *
+ * Usage in ccusage:
+ *   import { transformAndPush } from 'ai-heatmap/plugin'
+ *   await transformAndPush(dailyData, { repo: 'owner/repo' })
+ */
+import { execSync } from "node:child_process";
+
+/**
+ * Transform ccusage daily data to react-activity-calendar format.
+ * @param {Array} daily - ccusage daily output array
+ * @returns {Array} activity calendar data
+ */
+export function transform(daily) {
+  const costs = daily.map((d) => d.totalCost);
+  const maxCost = Math.max(...costs);
+
+  function toLevel(cost) {
+    if (cost === 0 || maxCost === 0) return 0;
+    const ratio = cost / maxCost;
+    if (ratio <= 0.25) return 1;
+    if (ratio <= 0.5) return 2;
+    if (ratio <= 0.75) return 3;
+    return 4;
+  }
+
+  return daily.map((d) => ({
+    date: d.date,
+    count: Math.round(d.totalCost * 100) / 100,
+    level: toLevel(d.totalCost),
+    totalTokens: d.totalTokens,
+    modelsUsed: d.modelsUsed,
+  }));
+}
+
+/**
+ * Push data.json to a GitHub repo using gh CLI.
+ * @param {Array} activities - transformed activity data
+ * @param {object} opts - { repo: 'owner/repo' }
+ */
+export function push(activities, { repo }) {
+  const content = Buffer.from(JSON.stringify(activities, null, 2)).toString(
+    "base64",
+  );
+
+  // Get current file SHA if exists
+  let sha = "";
+  try {
+    sha = execSync(
+      `gh api repos/${repo}/contents/public/data.json --jq .sha 2>/dev/null`,
+      { encoding: "utf-8" },
+    ).trim();
+  } catch {
+    // File doesn't exist yet
+  }
+
+  const payload = {
+    message: `Update heatmap data (${new Date().toISOString().slice(0, 10)})`,
+    content,
+  };
+  if (sha) payload.sha = sha;
+
+  const tmpFile = `/tmp/ai-heatmap-payload-${Date.now()}.json`;
+  const { writeFileSync, unlinkSync } = await import("node:fs");
+  writeFileSync(tmpFile, JSON.stringify(payload));
+
+  try {
+    execSync(
+      `gh api repos/${repo}/contents/public/data.json -X PUT --input ${tmpFile}`,
+      { stdio: "inherit" },
+    );
+    console.log(`Updated public/data.json in ${repo}`);
+  } finally {
+    try {
+      unlinkSync(tmpFile);
+    } catch {}
+  }
+}
+
+/**
+ * Full pipeline: transform ccusage data and push to repo.
+ * @param {Array} daily - ccusage daily output array
+ * @param {object} opts - { repo: 'owner/repo' }
+ */
+export async function transformAndPush(daily, opts) {
+  const activities = transform(daily);
+  console.log(`Transformed ${activities.length} days of data`);
+  await push(activities, opts);
+}

--- a/heatmap.config.json
+++ b/heatmap.config.json
@@ -1,0 +1,18 @@
+{
+  "colorScheme": "light",
+  "theme": "",
+  "blockSize": 16,
+  "blockMargin": 4,
+  "blockRadius": 3,
+  "bg": "",
+  "textColor": "",
+  "start": "",
+  "end": "",
+  "stats": {
+    "dailyAvg": true,
+    "weeklyAvg": true,
+    "peak": true,
+    "activeDays": true
+  },
+  "weekday": true
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Heatmap</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3857 @@
+{
+  "name": "ai-heatmap",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-heatmap",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "react": "^19.2.4",
+        "react-activity-calendar": "^3.1.1",
+        "react-dom": "^19.2.4",
+        "react-tooltip": "^5.30.0"
+      },
+      "bin": {
+        "ai-heatmap": "bin/cli.mjs"
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vercel/node": "^5.6.4",
+        "@vitejs/plugin-react": "^5.1.4",
+        "typescript": "^5.9.3",
+        "vite": "^7.3.1"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bytecodealliance/preview2-shim": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/preview2-shim/-/preview2-shim-0.17.6.tgz",
+      "integrity": "sha512-n3cM88gTen5980UOBAD6xDcNNL3ocTK8keab21bpx1ONdA+ARj7uD1qoFxOWCyKlkpSi195FH+GeAut7Oc6zZw==",
+      "dev": true,
+      "license": "(Apache-2.0 WITH LLVM-exception)"
+    },
+    "node_modules/@edge-runtime/format": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/format/-/format-2.2.1.tgz",
+      "integrity": "sha512-JQTRVuiusQLNNLe2W9tnzBlV/GvSVcozLl4XZHk5swnRZ/v6jp8TqR8P7sqmJsQqblDZ3EztcWmLDbhRje/+8g==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/node-utils": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/node-utils/-/node-utils-2.3.0.tgz",
+      "integrity": "sha512-uUtx8BFoO1hNxtHjp3eqVPC/mWImGb2exOfGjMLUoipuWgjej+f4o/VP4bUI8U40gu7Teogd5VTeZUkGvJSPOQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/ponyfill": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/ponyfill/-/ponyfill-2.4.2.tgz",
+      "integrity": "sha512-oN17GjFr69chu6sDLvXxdhg0Qe8EZviGSuqzR9qOiKh4MhFYGdBBcqRNzdmYeAdeRzOW2mM9yil4RftUQ7sUOA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/primitives": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-4.1.0.tgz",
+      "integrity": "sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@edge-runtime/vm": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.2.0.tgz",
+      "integrity": "sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@edge-runtime/primitives": "4.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.4",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.18",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.18.tgz",
+      "integrity": "sha512-xJWJxvmy3a05j643gQt+pRbht5XnTlGpsEsAPnMi5F5YTOEEJymA90uZKBD8OvIv5XvZ1qi4GcccSlqT3Bq44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.7",
+        "@floating-ui/utils": "^0.2.10",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
+      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-2.0.3.tgz",
+      "integrity": "sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "consola": "^3.2.3",
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^7.0.5",
+        "node-fetch": "^2.6.7",
+        "nopt": "^8.0.0",
+        "semver": "^7.5.3",
+        "tar": "^7.4.0"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@renovatebot/pep440": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@renovatebot/pep440/-/pep440-4.2.1.tgz",
+      "integrity": "sha512-2FK1hF93Fuf1laSdfiEmJvSJPVIDHEUTz68D3Fi9s0IZrrpaEcj6pTFBTbYvsgC5du4ogrtf5re7yMMvrKNgkw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.9.0 || ^22.11.0 || ^24",
+        "pnpm": "^10.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.11.1.tgz",
+      "integrity": "sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.2.7",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^1.0.4",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@ts-morph/common/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vercel/build-utils": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@vercel/build-utils/-/build-utils-13.4.1.tgz",
+      "integrity": "sha512-lYiPTGgtBJMAkFb78djW+n17VhmxjCln0RvDu+7N8Bra43AmtxyjNNaDeBstZqm9dJX8uWwgXLcT2e/ZhaZfUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/python-analysis": "0.4.1"
+      }
+    },
+    "node_modules/@vercel/error-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@vercel/error-utils/-/error-utils-2.0.3.tgz",
+      "integrity": "sha512-CqC01WZxbLUxoiVdh9B/poPbNpY9U+tO1N9oWHwTl5YAZxcqXmmWJ8KNMFItJCUUWdY3J3xv8LvAuQv2KZ5YdQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@vercel/nft": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.1.1.tgz",
+      "integrity": "sha512-mKMGa7CEUcXU75474kOeqHbtvK1kAcu4wiahhmlUenB5JbTQB8wVlDI8CyHR3rpGo0qlzoRWqcDzI41FUoBJCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/node-pre-gyp": "^2.0.0",
+        "@rollup/pluginutils": "^5.1.3",
+        "acorn": "^8.6.0",
+        "acorn-import-attributes": "^1.9.5",
+        "async-sema": "^3.1.1",
+        "bindings": "^1.4.0",
+        "estree-walker": "2.0.2",
+        "glob": "^13.0.0",
+        "graceful-fs": "^4.2.9",
+        "node-gyp-build": "^4.2.2",
+        "picomatch": "^4.0.2",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "nft": "out/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@vercel/node": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/@vercel/node/-/node-5.6.4.tgz",
+      "integrity": "sha512-vALWvjxXA4bQeuf5YjS3V8oF5GWpwUzXhptP1cIekpm3yiCIgCyzrTbAtvzD6tXSK6zchB+Vdu97l+yCfCnuDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@edge-runtime/node-utils": "2.3.0",
+        "@edge-runtime/primitives": "4.1.0",
+        "@edge-runtime/vm": "3.2.0",
+        "@types/node": "20.11.0",
+        "@vercel/build-utils": "13.4.1",
+        "@vercel/error-utils": "2.0.3",
+        "@vercel/nft": "1.1.1",
+        "@vercel/static-config": "3.1.2",
+        "async-listen": "3.0.0",
+        "cjs-module-lexer": "1.2.3",
+        "edge-runtime": "2.5.9",
+        "es-module-lexer": "1.4.1",
+        "esbuild": "0.27.0",
+        "etag": "1.8.1",
+        "mime-types": "2.1.35",
+        "node-fetch": "2.6.9",
+        "path-to-regexp": "6.1.0",
+        "path-to-regexp-updated": "npm:path-to-regexp@6.3.0",
+        "ts-morph": "12.0.0",
+        "tsx": "4.21.0",
+        "typescript": "npm:typescript@5.9.3",
+        "undici": "5.28.4"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/android-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/android-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/@types/node": {
+      "version": "20.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.0.tgz",
+      "integrity": "sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/esbuild": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.0",
+        "@esbuild/android-arm": "0.27.0",
+        "@esbuild/android-arm64": "0.27.0",
+        "@esbuild/android-x64": "0.27.0",
+        "@esbuild/darwin-arm64": "0.27.0",
+        "@esbuild/darwin-x64": "0.27.0",
+        "@esbuild/freebsd-arm64": "0.27.0",
+        "@esbuild/freebsd-x64": "0.27.0",
+        "@esbuild/linux-arm": "0.27.0",
+        "@esbuild/linux-arm64": "0.27.0",
+        "@esbuild/linux-ia32": "0.27.0",
+        "@esbuild/linux-loong64": "0.27.0",
+        "@esbuild/linux-mips64el": "0.27.0",
+        "@esbuild/linux-ppc64": "0.27.0",
+        "@esbuild/linux-riscv64": "0.27.0",
+        "@esbuild/linux-s390x": "0.27.0",
+        "@esbuild/linux-x64": "0.27.0",
+        "@esbuild/netbsd-arm64": "0.27.0",
+        "@esbuild/netbsd-x64": "0.27.0",
+        "@esbuild/openbsd-arm64": "0.27.0",
+        "@esbuild/openbsd-x64": "0.27.0",
+        "@esbuild/openharmony-arm64": "0.27.0",
+        "@esbuild/sunos-x64": "0.27.0",
+        "@esbuild/win32-arm64": "0.27.0",
+        "@esbuild/win32-ia32": "0.27.0",
+        "@esbuild/win32-x64": "0.27.0"
+      }
+    },
+    "node_modules/@vercel/node/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vercel/python-analysis": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@vercel/python-analysis/-/python-analysis-0.4.1.tgz",
+      "integrity": "sha512-Ae6zayRNAO//z9ULOV+T8sjJFJLfA0OU540/BDkaVWHWhlqElIA7uyi71WuD7Ls06CDVpKYNRysv3keJaVbwow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bytecodealliance/preview2-shim": "0.17.6",
+        "@renovatebot/pep440": "4.2.1",
+        "fs-extra": "11.1.1",
+        "js-yaml": "4.1.1",
+        "minimatch": "10.1.1",
+        "pip-requirements-js": "1.0.2",
+        "smol-toml": "1.5.2",
+        "zod": "3.22.4"
+      }
+    },
+    "node_modules/@vercel/static-config": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@vercel/static-config/-/static-config-3.1.2.tgz",
+      "integrity": "sha512-2d+TXr6K30w86a+WbMbGm2W91O0UzO5VeemZYBBUJbCjk/5FLLGIi8aV6RS2+WmaRvtcqNTn2pUA7nCOK3bGcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "8.6.3",
+        "json-schema-to-ts": "1.6.4",
+        "ts-morph": "12.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
+      "integrity": "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.6.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/async-listen": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.0.0.tgz",
+      "integrity": "sha512-V+SsTpDqkrWTimiotsyl33ePSjA5/KrithwupuvJ6ztsqPvGv6ge4OredFhPffVXiLN/QUWvE0XcqJaYgt6fOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/async-sema": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
+      "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001770",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
+      "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
+    "node_modules/code-block-writer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.1.tgz",
+      "integrity": "sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/convert-hrtime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-3.0.0.tgz",
+      "integrity": "sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/edge-runtime": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/edge-runtime/-/edge-runtime-2.5.9.tgz",
+      "integrity": "sha512-pk+k0oK0PVXdlT4oRp4lwh+unuKB7Ng4iZ2HB+EZ7QCEQizX360Rp/F4aRpgpRgdP2ufB35N+1KppHmYjqIGSg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@edge-runtime/format": "2.2.1",
+        "@edge-runtime/ponyfill": "2.4.2",
+        "@edge-runtime/vm": "3.2.0",
+        "async-listen": "3.0.1",
+        "mri": "1.2.0",
+        "picocolors": "1.0.0",
+        "pretty-ms": "7.0.1",
+        "signal-exit": "4.0.2",
+        "time-span": "4.0.0"
+      },
+      "bin": {
+        "edge-runtime": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/edge-runtime/node_modules/async-listen": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.0.1.tgz",
+      "integrity": "sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/edge-runtime/node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.286",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
+      "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
+      "integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.5.tgz",
+      "integrity": "sha512-BzXxZg24Ibra1pbQ/zE7Kys4Ua1ks7Bn6pKLkVPZ9FZe4JQS6/Q7ef3LG1H+k7lUf5l4T3PLSyYyYJVYUvfgTw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
+      "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jackspeak": "^4.2.3"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
+      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-1.6.4.tgz",
+      "integrity": "sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.6",
+        "ts-toolbelt": "^6.15.5"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^3.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/ohm-js": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-17.5.0.tgz",
+      "integrity": "sha512-l4Sa7026+6jsvYbt0PXKmL+f+ML32fD++IznLgxDhx2t9Cx6NC7zwRqblCujPHGGmkQerHoeBzRutdxaw/S72g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.1"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
+      "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp-updated": {
+      "name": "path-to-regexp",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pip-requirements-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pip-requirements-js/-/pip-requirements-js-1.0.2.tgz",
+      "integrity": "sha512-awqoNOSOl4Blu4E4Hzp7jL0g8WKEhCwO+s7C2ibtIW3CAJMwspgoTXd4vnHd21UmhdrsI44Pn8FFSuA8QKrzvg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "ohm-js": "^17.1.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-activity-calendar": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-activity-calendar/-/react-activity-calendar-3.1.1.tgz",
+      "integrity": "sha512-YvHNS4anlW3Xy0fxOU2ZTWrJkOt0ALxX8IfgDRg6jr/vgYsbh//4djf2c7CPhYNROh+5oYZzR0EJaPbrFUj2tA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.12",
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-tooltip": {
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.30.0.tgz",
+      "integrity": "sha512-Yn8PfbgQ/wmqnL7oBpz1QiDaLKrzZMdSUUdk7nVeGTwzbxCAJiJzR4VSYW+eIO42F1INt57sPUmpgKv0KwJKtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1",
+        "classnames": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+      "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
+      "integrity": "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
+    "node_modules/tar": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/time-span": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-4.0.0.tgz",
+      "integrity": "sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-hrtime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ts-morph": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-12.0.0.tgz",
+      "integrity": "sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.11.0",
+        "code-block-writer": "^10.1.1"
+      }
+    },
+    "node_modules/ts-toolbelt": {
+      "version": "6.15.5",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
+      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "ai-heatmap",
+  "version": "1.0.0",
+  "description": "AI usage cost heatmap powered by ccusage + react-activity-calendar",
+  "type": "module",
+  "bin": {
+    "ai-heatmap": "./bin/cli.mjs"
+  },
+  "files": [
+    "bin/",
+    "scripts/",
+    "src/",
+    "public/",
+    "index.html",
+    "vite.config.ts",
+    "tsconfig.json",
+    ".github/"
+  ],
+  "scripts": {
+    "generate": "node scripts/generate.mjs",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "generate:svg": "node scripts/generate-svg.mjs",
+    "deploy": "npm run generate && npm run generate:svg && npm run build"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "react": "^19.2.4",
+    "react-activity-calendar": "^3.1.1",
+    "react-dom": "^19.2.4",
+    "react-tooltip": "^5.30.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vercel/node": "^5.6.4",
+    "@vitejs/plugin-react": "^5.1.4",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1"
+  }
+}

--- a/public/data.json
+++ b/public/data.json
@@ -1,0 +1,2236 @@
+[
+  {
+    "date": "2025-02-19",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-02-20",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-02-21",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-02-22",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-02-23",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-02-24",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-02-25",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-02-26",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-02-27",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-02-28",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-01",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-02",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-03",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-04",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-05",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-06",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-07",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-08",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-09",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-10",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-11",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-12",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-13",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-14",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-15",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-16",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-17",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-18",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-19",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-20",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-21",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-22",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-23",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-24",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-25",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-26",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-27",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-28",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-29",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-30",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-03-31",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-01",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-02",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-03",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-04",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-05",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-06",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-07",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-08",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-09",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-10",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-11",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-12",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-13",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-14",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-15",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-16",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-17",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-18",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-19",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-20",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-21",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-22",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-23",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-24",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-25",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-26",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-27",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-28",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-29",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-04-30",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-01",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-02",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-03",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-04",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-05",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-06",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-07",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-08",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-09",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-10",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-11",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-12",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-13",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-14",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-15",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-16",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-17",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-18",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-19",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-20",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-21",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-22",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-23",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-24",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-25",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-26",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-27",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-28",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-29",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-30",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-05-31",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-01",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-02",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-03",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-04",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-05",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-06",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-07",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-08",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-09",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-10",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-11",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-12",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-13",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-14",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-15",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-16",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-17",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-18",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-19",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-20",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-21",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-22",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-23",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-24",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-25",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-26",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-27",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-28",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-29",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-06-30",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-01",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-02",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-03",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-04",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-05",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-06",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-07",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-08",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-09",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-10",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-11",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-12",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-13",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-14",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-15",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-16",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-17",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-18",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-19",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-20",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-21",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-22",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-23",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-24",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-25",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-26",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-27",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-28",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-29",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-30",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-07-31",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-01",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-02",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-03",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-04",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-05",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-06",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-07",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-08",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-09",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-10",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-11",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-12",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-13",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-14",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-15",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-16",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-17",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-18",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-19",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-20",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-21",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-22",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-23",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-24",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-25",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-26",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-27",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-28",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-29",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-30",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-08-31",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-01",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-02",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-03",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-04",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-05",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-06",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-07",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-08",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-09",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-10",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-11",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-12",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-13",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-14",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-15",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-16",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-17",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-18",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-19",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-20",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-21",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-22",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-23",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-24",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-25",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-26",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-27",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-28",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-29",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-09-30",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-01",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-02",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-03",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-04",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-05",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-06",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-07",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-08",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-09",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-10",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-11",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-12",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-13",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-14",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-15",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-16",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-17",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-18",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-19",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-20",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-21",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-22",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-23",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-24",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-25",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-26",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-27",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-28",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-29",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-30",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-10-31",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-01",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-02",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-03",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-04",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-05",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-06",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-07",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-08",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-09",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-10",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-11",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-12",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-13",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-14",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-15",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-16",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-17",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-18",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-19",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-20",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-21",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-22",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-23",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-24",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-25",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-26",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-27",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-28",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-29",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-11-30",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-01",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-02",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-03",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-04",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-05",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-06",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-07",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-08",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-09",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-10",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-11",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-12",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-13",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-14",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-15",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-16",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-17",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-18",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-19",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-20",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-21",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-22",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-23",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-24",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-25",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-26",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-27",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-28",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-29",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-30",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2025-12-31",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-01",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-02",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-03",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-04",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-05",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-06",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-07",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-08",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-09",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-10",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-11",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-12",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-13",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-14",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-15",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-16",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-17",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-18",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-19",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-20",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-21",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-22",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-23",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-24",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-25",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-26",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-27",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-28",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-29",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-30",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-01-31",
+    "count": 0,
+    "level": 0
+  },
+  {
+    "date": "2026-02-01",
+    "count": 27.9,
+    "level": 1,
+    "inputTokens": 4991,
+    "outputTokens": 1218,
+    "totalTokens": 39141520,
+    "cacheHitRate": 96,
+    "modelsUsed": [
+      "claude-opus-4-5-20251101",
+      "claude-sonnet-4-5-20250929"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-opus-4-5-20251101",
+        "cost": 27.63
+      },
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 0.27
+      }
+    ]
+  },
+  {
+    "date": "2026-02-02",
+    "count": 136.12,
+    "level": 4,
+    "inputTokens": 16907,
+    "outputTokens": 6208,
+    "totalTokens": 153981637,
+    "cacheHitRate": 90,
+    "modelsUsed": [
+      "claude-opus-4-5-20251101",
+      "claude-sonnet-4-5-20250929",
+      "claude-haiku-4-5-20251001"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-opus-4-5-20251101",
+        "cost": 91.93
+      },
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 43.52
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 0.67
+      }
+    ]
+  },
+  {
+    "date": "2026-02-03",
+    "count": 59.67,
+    "level": 2,
+    "inputTokens": 8196,
+    "outputTokens": 3859,
+    "totalTokens": 67570780,
+    "cacheHitRate": 92,
+    "modelsUsed": [
+      "claude-opus-4-5-20251101",
+      "claude-haiku-4-5-20251001",
+      "claude-sonnet-4-5-20250929"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-opus-4-5-20251101",
+        "cost": 55.66
+      },
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 3.08
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 0.94
+      }
+    ]
+  },
+  {
+    "date": "2026-02-04",
+    "count": 123.34,
+    "level": 4,
+    "inputTokens": 31675,
+    "outputTokens": 8687,
+    "totalTokens": 168834147,
+    "cacheHitRate": 91,
+    "modelsUsed": [
+      "claude-opus-4-5-20251101",
+      "claude-sonnet-4-5-20250929",
+      "claude-haiku-4-5-20251001"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-opus-4-5-20251101",
+        "cost": 66.3
+      },
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 54.96
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 2.09
+      }
+    ]
+  },
+  {
+    "date": "2026-02-05",
+    "count": 120.81,
+    "level": 4,
+    "inputTokens": 13181,
+    "outputTokens": 17691,
+    "totalTokens": 127651583,
+    "cacheHitRate": 89,
+    "modelsUsed": [
+      "claude-opus-4-5-20251101",
+      "claude-sonnet-4-5-20250929",
+      "claude-haiku-4-5-20251001"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-opus-4-5-20251101",
+        "cost": 83.19
+      },
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 37.4
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 0.22
+      }
+    ]
+  },
+  {
+    "date": "2026-02-06",
+    "count": 134.48,
+    "level": 4,
+    "inputTokens": 10421,
+    "outputTokens": 41354,
+    "totalTokens": 187092162,
+    "cacheHitRate": 95,
+    "modelsUsed": [
+      "claude-opus-4-5-20251101",
+      "claude-sonnet-4-5-20250929",
+      "claude-haiku-4-5-20251001",
+      "claude-opus-4-6"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-opus-4-6",
+        "cost": 84.35
+      },
+      {
+        "model": "claude-opus-4-5-20251101",
+        "cost": 30.01
+      },
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 19.19
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 0.93
+      }
+    ]
+  },
+  {
+    "date": "2026-02-07",
+    "count": 101.17,
+    "level": 3,
+    "inputTokens": 10331,
+    "outputTokens": 19797,
+    "totalTokens": 114348109,
+    "cacheHitRate": 89,
+    "modelsUsed": [
+      "claude-opus-4-6",
+      "claude-sonnet-4-5-20250929",
+      "claude-haiku-4-5-20251001"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-opus-4-6",
+        "cost": 61.69
+      },
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 38.21
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 1.27
+      }
+    ]
+  },
+  {
+    "date": "2026-02-08",
+    "count": 126.57,
+    "level": 4,
+    "inputTokens": 9773,
+    "outputTokens": 28122,
+    "totalTokens": 131570471,
+    "cacheHitRate": 88,
+    "modelsUsed": [
+      "claude-opus-4-6",
+      "claude-sonnet-4-5-20250929",
+      "claude-haiku-4-5-20251001"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-opus-4-6",
+        "cost": 84.63
+      },
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 41.43
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 0.51
+      }
+    ]
+  },
+  {
+    "date": "2026-02-09",
+    "count": 96.71,
+    "level": 3,
+    "inputTokens": 7851,
+    "outputTokens": 48808,
+    "totalTokens": 126643382,
+    "cacheHitRate": 94,
+    "modelsUsed": [
+      "claude-sonnet-4-5-20250929",
+      "claude-opus-4-6",
+      "claude-haiku-4-5-20251001"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-opus-4-6",
+        "cost": 79.77
+      },
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 16.53
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 0.41
+      }
+    ]
+  },
+  {
+    "date": "2026-02-10",
+    "count": 108.43,
+    "level": 4,
+    "inputTokens": 6438,
+    "outputTokens": 26366,
+    "totalTokens": 150681738,
+    "cacheHitRate": 95,
+    "modelsUsed": [
+      "claude-opus-4-6",
+      "claude-sonnet-4-5-20250929",
+      "claude-haiku-4-5-20251001"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-opus-4-6",
+        "cost": 95.89
+      },
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 11.85
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 0.68
+      }
+    ]
+  },
+  {
+    "date": "2026-02-11",
+    "count": 74.32,
+    "level": 3,
+    "inputTokens": 10895,
+    "outputTokens": 12358,
+    "totalTokens": 93013129,
+    "cacheHitRate": 92,
+    "modelsUsed": [
+      "claude-opus-4-6",
+      "claude-sonnet-4-5-20250929",
+      "claude-haiku-4-5-20251001"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-opus-4-6",
+        "cost": 54.09
+      },
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 19.97
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 0.26
+      }
+    ]
+  },
+  {
+    "date": "2026-02-12",
+    "count": 141.43,
+    "level": 4,
+    "inputTokens": 32806,
+    "outputTokens": 15244,
+    "totalTokens": 258726747,
+    "cacheHitRate": 94,
+    "modelsUsed": [
+      "claude-sonnet-4-5-20250929",
+      "claude-opus-4-6",
+      "claude-haiku-4-5-20251001"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 111.88
+      },
+      {
+        "model": "claude-opus-4-6",
+        "cost": 28.67
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 0.88
+      }
+    ]
+  },
+  {
+    "date": "2026-02-13",
+    "count": 99.42,
+    "level": 3,
+    "inputTokens": 19685,
+    "outputTokens": 10882,
+    "totalTokens": 186473069,
+    "cacheHitRate": 93,
+    "modelsUsed": [
+      "claude-sonnet-4-5-20250929",
+      "claude-opus-4-6",
+      "claude-haiku-4-5-20251001"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 98
+      },
+      {
+        "model": "claude-opus-4-6",
+        "cost": 1.19
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 0.23
+      }
+    ]
+  },
+  {
+    "date": "2026-02-14",
+    "count": 101.46,
+    "level": 3,
+    "inputTokens": 18373,
+    "outputTokens": 5401,
+    "totalTokens": 188184796,
+    "cacheHitRate": 93,
+    "modelsUsed": [
+      "claude-sonnet-4-5-20250929",
+      "claude-opus-4-6"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 97.33
+      },
+      {
+        "model": "claude-opus-4-6",
+        "cost": 4.12
+      }
+    ]
+  },
+  {
+    "date": "2026-02-15",
+    "count": 94.65,
+    "level": 3,
+    "inputTokens": 21968,
+    "outputTokens": 5227,
+    "totalTokens": 176449521,
+    "cacheHitRate": 93,
+    "modelsUsed": [
+      "claude-sonnet-4-5-20250929",
+      "claude-opus-4-6",
+      "claude-haiku-4-5-20251001"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 93.03
+      },
+      {
+        "model": "claude-opus-4-6",
+        "cost": 1.57
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 0.04
+      }
+    ]
+  },
+  {
+    "date": "2026-02-16",
+    "count": 69.87,
+    "level": 2,
+    "inputTokens": 13911,
+    "outputTokens": 3745,
+    "totalTokens": 131466709,
+    "cacheHitRate": 93,
+    "modelsUsed": [
+      "claude-sonnet-4-5-20250929",
+      "claude-haiku-4-5-20251001"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 69.07
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 0.79
+      }
+    ]
+  },
+  {
+    "date": "2026-02-17",
+    "count": 77.63,
+    "level": 3,
+    "inputTokens": 13509,
+    "outputTokens": 6714,
+    "totalTokens": 113500001,
+    "cacheHitRate": 90,
+    "modelsUsed": [
+      "claude-sonnet-4-5-20250929",
+      "claude-haiku-4-5-20251001",
+      "claude-opus-4-6"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 64.59
+      },
+      {
+        "model": "claude-opus-4-6",
+        "cost": 12.57
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 0.47
+      }
+    ]
+  },
+  {
+    "date": "2026-02-18",
+    "count": 123.06,
+    "level": 4,
+    "inputTokens": 5888,
+    "outputTokens": 34283,
+    "totalTokens": 144050754,
+    "cacheHitRate": 93,
+    "modelsUsed": [
+      "claude-sonnet-4-5-20250929",
+      "claude-opus-4-6",
+      "claude-haiku-4-5-20251001",
+      "claude-sonnet-4-6"
+    ],
+    "modelBreakdowns": [
+      {
+        "model": "claude-opus-4-6",
+        "cost": 119.33
+      },
+      {
+        "model": "claude-sonnet-4-5-20250929",
+        "cost": 2.5
+      },
+      {
+        "model": "claude-haiku-4-5-20251001",
+        "cost": 0.86
+      },
+      {
+        "model": "claude-sonnet-4-6",
+        "cost": 0.36
+      }
+    ]
+  }
+]

--- a/public/heatmap.svg
+++ b/public/heatmap.svg
@@ -1,0 +1,410 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1132" height="466" viewBox="0 0 1132 466">
+<rect width="100%" height="100%" fill="transparent" rx="6"/>
+<style>text{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;fill:#24292f}.month{font-size:10px}.day{font-size:10px}.legend-label{font-size:10px;fill:#666}.total{font-size:11px;font-weight:600}.stat{font-size:11px;fill:#666}.stat-val{font-size:11px;font-weight:600;fill:#24292f}.bar-label{font-size:11px;fill:#666}.bar-val{font-size:10px;fill:#666}.section-title{font-size:12px;font-weight:600}</style>
+<text x="52" y="30" class="month">Feb</text>
+<text x="92" y="30" class="month">Mar</text>
+<text x="192" y="30" class="month">Apr</text>
+<text x="272" y="30" class="month">May</text>
+<text x="352" y="30" class="month">Jun</text>
+<text x="452" y="30" class="month">Jul</text>
+<text x="532" y="30" class="month">Aug</text>
+<text x="632" y="30" class="month">Sep</text>
+<text x="712" y="30" class="month">Oct</text>
+<text x="792" y="30" class="month">Nov</text>
+<text x="892" y="30" class="month">Dec</text>
+<text x="972" y="30" class="month">Jan</text>
+<text x="1052" y="30" class="month">Feb</text>
+<text x="16" y="74" class="day">Mon</text>
+<text x="16" y="114" class="day">Wed</text>
+<text x="16" y="154" class="day">Fri</text>
+<rect x="52" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-02-19: No data</title></rect>
+<rect x="52" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-02-20: No data</title></rect>
+<rect x="52" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-02-21: No data</title></rect>
+<rect x="52" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-02-22: No data</title></rect>
+<rect x="72" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-02-23: No data</title></rect>
+<rect x="72" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-02-24: No data</title></rect>
+<rect x="72" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-02-25: No data</title></rect>
+<rect x="72" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-02-26: No data</title></rect>
+<rect x="72" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-02-27: No data</title></rect>
+<rect x="72" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-02-28: No data</title></rect>
+<rect x="72" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-01: No data</title></rect>
+<rect x="92" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-02: No data</title></rect>
+<rect x="92" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-03: No data</title></rect>
+<rect x="92" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-04: No data</title></rect>
+<rect x="92" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-05: No data</title></rect>
+<rect x="92" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-06: No data</title></rect>
+<rect x="92" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-07: No data</title></rect>
+<rect x="92" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-08: No data</title></rect>
+<rect x="112" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-09: No data</title></rect>
+<rect x="112" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-10: No data</title></rect>
+<rect x="112" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-11: No data</title></rect>
+<rect x="112" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-12: No data</title></rect>
+<rect x="112" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-13: No data</title></rect>
+<rect x="112" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-14: No data</title></rect>
+<rect x="112" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-15: No data</title></rect>
+<rect x="132" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-16: No data</title></rect>
+<rect x="132" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-17: No data</title></rect>
+<rect x="132" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-18: No data</title></rect>
+<rect x="132" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-19: No data</title></rect>
+<rect x="132" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-20: No data</title></rect>
+<rect x="132" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-21: No data</title></rect>
+<rect x="132" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-22: No data</title></rect>
+<rect x="152" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-23: No data</title></rect>
+<rect x="152" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-24: No data</title></rect>
+<rect x="152" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-25: No data</title></rect>
+<rect x="152" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-26: No data</title></rect>
+<rect x="152" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-27: No data</title></rect>
+<rect x="152" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-28: No data</title></rect>
+<rect x="152" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-29: No data</title></rect>
+<rect x="172" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-30: No data</title></rect>
+<rect x="172" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-03-31: No data</title></rect>
+<rect x="172" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-01: No data</title></rect>
+<rect x="172" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-02: No data</title></rect>
+<rect x="172" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-03: No data</title></rect>
+<rect x="172" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-04: No data</title></rect>
+<rect x="172" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-05: No data</title></rect>
+<rect x="192" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-06: No data</title></rect>
+<rect x="192" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-07: No data</title></rect>
+<rect x="192" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-08: No data</title></rect>
+<rect x="192" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-09: No data</title></rect>
+<rect x="192" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-10: No data</title></rect>
+<rect x="192" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-11: No data</title></rect>
+<rect x="192" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-12: No data</title></rect>
+<rect x="212" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-13: No data</title></rect>
+<rect x="212" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-14: No data</title></rect>
+<rect x="212" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-15: No data</title></rect>
+<rect x="212" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-16: No data</title></rect>
+<rect x="212" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-17: No data</title></rect>
+<rect x="212" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-18: No data</title></rect>
+<rect x="212" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-19: No data</title></rect>
+<rect x="232" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-20: No data</title></rect>
+<rect x="232" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-21: No data</title></rect>
+<rect x="232" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-22: No data</title></rect>
+<rect x="232" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-23: No data</title></rect>
+<rect x="232" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-24: No data</title></rect>
+<rect x="232" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-25: No data</title></rect>
+<rect x="232" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-26: No data</title></rect>
+<rect x="252" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-27: No data</title></rect>
+<rect x="252" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-28: No data</title></rect>
+<rect x="252" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-29: No data</title></rect>
+<rect x="252" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-04-30: No data</title></rect>
+<rect x="252" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-01: No data</title></rect>
+<rect x="252" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-02: No data</title></rect>
+<rect x="252" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-03: No data</title></rect>
+<rect x="272" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-04: No data</title></rect>
+<rect x="272" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-05: No data</title></rect>
+<rect x="272" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-06: No data</title></rect>
+<rect x="272" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-07: No data</title></rect>
+<rect x="272" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-08: No data</title></rect>
+<rect x="272" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-09: No data</title></rect>
+<rect x="272" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-10: No data</title></rect>
+<rect x="292" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-11: No data</title></rect>
+<rect x="292" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-12: No data</title></rect>
+<rect x="292" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-13: No data</title></rect>
+<rect x="292" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-14: No data</title></rect>
+<rect x="292" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-15: No data</title></rect>
+<rect x="292" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-16: No data</title></rect>
+<rect x="292" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-17: No data</title></rect>
+<rect x="312" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-18: No data</title></rect>
+<rect x="312" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-19: No data</title></rect>
+<rect x="312" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-20: No data</title></rect>
+<rect x="312" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-21: No data</title></rect>
+<rect x="312" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-22: No data</title></rect>
+<rect x="312" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-23: No data</title></rect>
+<rect x="312" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-24: No data</title></rect>
+<rect x="332" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-25: No data</title></rect>
+<rect x="332" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-26: No data</title></rect>
+<rect x="332" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-27: No data</title></rect>
+<rect x="332" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-28: No data</title></rect>
+<rect x="332" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-29: No data</title></rect>
+<rect x="332" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-30: No data</title></rect>
+<rect x="332" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-05-31: No data</title></rect>
+<rect x="352" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-01: No data</title></rect>
+<rect x="352" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-02: No data</title></rect>
+<rect x="352" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-03: No data</title></rect>
+<rect x="352" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-04: No data</title></rect>
+<rect x="352" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-05: No data</title></rect>
+<rect x="352" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-06: No data</title></rect>
+<rect x="352" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-07: No data</title></rect>
+<rect x="372" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-08: No data</title></rect>
+<rect x="372" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-09: No data</title></rect>
+<rect x="372" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-10: No data</title></rect>
+<rect x="372" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-11: No data</title></rect>
+<rect x="372" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-12: No data</title></rect>
+<rect x="372" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-13: No data</title></rect>
+<rect x="372" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-14: No data</title></rect>
+<rect x="392" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-15: No data</title></rect>
+<rect x="392" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-16: No data</title></rect>
+<rect x="392" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-17: No data</title></rect>
+<rect x="392" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-18: No data</title></rect>
+<rect x="392" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-19: No data</title></rect>
+<rect x="392" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-20: No data</title></rect>
+<rect x="392" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-21: No data</title></rect>
+<rect x="412" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-22: No data</title></rect>
+<rect x="412" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-23: No data</title></rect>
+<rect x="412" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-24: No data</title></rect>
+<rect x="412" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-25: No data</title></rect>
+<rect x="412" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-26: No data</title></rect>
+<rect x="412" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-27: No data</title></rect>
+<rect x="412" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-28: No data</title></rect>
+<rect x="432" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-29: No data</title></rect>
+<rect x="432" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-06-30: No data</title></rect>
+<rect x="432" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-01: No data</title></rect>
+<rect x="432" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-02: No data</title></rect>
+<rect x="432" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-03: No data</title></rect>
+<rect x="432" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-04: No data</title></rect>
+<rect x="432" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-05: No data</title></rect>
+<rect x="452" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-06: No data</title></rect>
+<rect x="452" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-07: No data</title></rect>
+<rect x="452" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-08: No data</title></rect>
+<rect x="452" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-09: No data</title></rect>
+<rect x="452" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-10: No data</title></rect>
+<rect x="452" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-11: No data</title></rect>
+<rect x="452" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-12: No data</title></rect>
+<rect x="472" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-13: No data</title></rect>
+<rect x="472" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-14: No data</title></rect>
+<rect x="472" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-15: No data</title></rect>
+<rect x="472" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-16: No data</title></rect>
+<rect x="472" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-17: No data</title></rect>
+<rect x="472" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-18: No data</title></rect>
+<rect x="472" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-19: No data</title></rect>
+<rect x="492" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-20: No data</title></rect>
+<rect x="492" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-21: No data</title></rect>
+<rect x="492" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-22: No data</title></rect>
+<rect x="492" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-23: No data</title></rect>
+<rect x="492" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-24: No data</title></rect>
+<rect x="492" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-25: No data</title></rect>
+<rect x="492" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-26: No data</title></rect>
+<rect x="512" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-27: No data</title></rect>
+<rect x="512" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-28: No data</title></rect>
+<rect x="512" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-29: No data</title></rect>
+<rect x="512" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-30: No data</title></rect>
+<rect x="512" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-07-31: No data</title></rect>
+<rect x="512" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-01: No data</title></rect>
+<rect x="512" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-02: No data</title></rect>
+<rect x="532" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-03: No data</title></rect>
+<rect x="532" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-04: No data</title></rect>
+<rect x="532" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-05: No data</title></rect>
+<rect x="532" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-06: No data</title></rect>
+<rect x="532" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-07: No data</title></rect>
+<rect x="532" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-08: No data</title></rect>
+<rect x="532" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-09: No data</title></rect>
+<rect x="552" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-10: No data</title></rect>
+<rect x="552" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-11: No data</title></rect>
+<rect x="552" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-12: No data</title></rect>
+<rect x="552" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-13: No data</title></rect>
+<rect x="552" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-14: No data</title></rect>
+<rect x="552" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-15: No data</title></rect>
+<rect x="552" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-16: No data</title></rect>
+<rect x="572" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-17: No data</title></rect>
+<rect x="572" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-18: No data</title></rect>
+<rect x="572" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-19: No data</title></rect>
+<rect x="572" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-20: No data</title></rect>
+<rect x="572" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-21: No data</title></rect>
+<rect x="572" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-22: No data</title></rect>
+<rect x="572" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-23: No data</title></rect>
+<rect x="592" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-24: No data</title></rect>
+<rect x="592" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-25: No data</title></rect>
+<rect x="592" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-26: No data</title></rect>
+<rect x="592" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-27: No data</title></rect>
+<rect x="592" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-28: No data</title></rect>
+<rect x="592" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-29: No data</title></rect>
+<rect x="592" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-30: No data</title></rect>
+<rect x="612" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-08-31: No data</title></rect>
+<rect x="612" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-01: No data</title></rect>
+<rect x="612" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-02: No data</title></rect>
+<rect x="612" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-03: No data</title></rect>
+<rect x="612" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-04: No data</title></rect>
+<rect x="612" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-05: No data</title></rect>
+<rect x="612" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-06: No data</title></rect>
+<rect x="632" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-07: No data</title></rect>
+<rect x="632" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-08: No data</title></rect>
+<rect x="632" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-09: No data</title></rect>
+<rect x="632" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-10: No data</title></rect>
+<rect x="632" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-11: No data</title></rect>
+<rect x="632" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-12: No data</title></rect>
+<rect x="632" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-13: No data</title></rect>
+<rect x="652" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-14: No data</title></rect>
+<rect x="652" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-15: No data</title></rect>
+<rect x="652" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-16: No data</title></rect>
+<rect x="652" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-17: No data</title></rect>
+<rect x="652" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-18: No data</title></rect>
+<rect x="652" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-19: No data</title></rect>
+<rect x="652" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-20: No data</title></rect>
+<rect x="672" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-21: No data</title></rect>
+<rect x="672" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-22: No data</title></rect>
+<rect x="672" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-23: No data</title></rect>
+<rect x="672" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-24: No data</title></rect>
+<rect x="672" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-25: No data</title></rect>
+<rect x="672" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-26: No data</title></rect>
+<rect x="672" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-27: No data</title></rect>
+<rect x="692" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-28: No data</title></rect>
+<rect x="692" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-29: No data</title></rect>
+<rect x="692" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-09-30: No data</title></rect>
+<rect x="692" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-01: No data</title></rect>
+<rect x="692" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-02: No data</title></rect>
+<rect x="692" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-03: No data</title></rect>
+<rect x="692" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-04: No data</title></rect>
+<rect x="712" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-05: No data</title></rect>
+<rect x="712" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-06: No data</title></rect>
+<rect x="712" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-07: No data</title></rect>
+<rect x="712" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-08: No data</title></rect>
+<rect x="712" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-09: No data</title></rect>
+<rect x="712" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-10: No data</title></rect>
+<rect x="712" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-11: No data</title></rect>
+<rect x="732" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-12: No data</title></rect>
+<rect x="732" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-13: No data</title></rect>
+<rect x="732" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-14: No data</title></rect>
+<rect x="732" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-15: No data</title></rect>
+<rect x="732" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-16: No data</title></rect>
+<rect x="732" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-17: No data</title></rect>
+<rect x="732" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-18: No data</title></rect>
+<rect x="752" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-19: No data</title></rect>
+<rect x="752" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-20: No data</title></rect>
+<rect x="752" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-21: No data</title></rect>
+<rect x="752" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-22: No data</title></rect>
+<rect x="752" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-23: No data</title></rect>
+<rect x="752" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-24: No data</title></rect>
+<rect x="752" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-25: No data</title></rect>
+<rect x="772" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-26: No data</title></rect>
+<rect x="772" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-27: No data</title></rect>
+<rect x="772" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-28: No data</title></rect>
+<rect x="772" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-29: No data</title></rect>
+<rect x="772" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-30: No data</title></rect>
+<rect x="772" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-10-31: No data</title></rect>
+<rect x="772" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-01: No data</title></rect>
+<rect x="792" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-02: No data</title></rect>
+<rect x="792" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-03: No data</title></rect>
+<rect x="792" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-04: No data</title></rect>
+<rect x="792" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-05: No data</title></rect>
+<rect x="792" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-06: No data</title></rect>
+<rect x="792" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-07: No data</title></rect>
+<rect x="792" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-08: No data</title></rect>
+<rect x="812" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-09: No data</title></rect>
+<rect x="812" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-10: No data</title></rect>
+<rect x="812" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-11: No data</title></rect>
+<rect x="812" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-12: No data</title></rect>
+<rect x="812" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-13: No data</title></rect>
+<rect x="812" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-14: No data</title></rect>
+<rect x="812" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-15: No data</title></rect>
+<rect x="832" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-16: No data</title></rect>
+<rect x="832" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-17: No data</title></rect>
+<rect x="832" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-18: No data</title></rect>
+<rect x="832" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-19: No data</title></rect>
+<rect x="832" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-20: No data</title></rect>
+<rect x="832" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-21: No data</title></rect>
+<rect x="832" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-22: No data</title></rect>
+<rect x="852" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-23: No data</title></rect>
+<rect x="852" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-24: No data</title></rect>
+<rect x="852" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-25: No data</title></rect>
+<rect x="852" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-26: No data</title></rect>
+<rect x="852" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-27: No data</title></rect>
+<rect x="852" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-28: No data</title></rect>
+<rect x="852" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-29: No data</title></rect>
+<rect x="872" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-11-30: No data</title></rect>
+<rect x="872" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-01: No data</title></rect>
+<rect x="872" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-02: No data</title></rect>
+<rect x="872" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-03: No data</title></rect>
+<rect x="872" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-04: No data</title></rect>
+<rect x="872" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-05: No data</title></rect>
+<rect x="872" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-06: No data</title></rect>
+<rect x="892" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-07: No data</title></rect>
+<rect x="892" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-08: No data</title></rect>
+<rect x="892" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-09: No data</title></rect>
+<rect x="892" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-10: No data</title></rect>
+<rect x="892" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-11: No data</title></rect>
+<rect x="892" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-12: No data</title></rect>
+<rect x="892" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-13: No data</title></rect>
+<rect x="912" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-14: No data</title></rect>
+<rect x="912" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-15: No data</title></rect>
+<rect x="912" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-16: No data</title></rect>
+<rect x="912" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-17: No data</title></rect>
+<rect x="912" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-18: No data</title></rect>
+<rect x="912" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-19: No data</title></rect>
+<rect x="912" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-20: No data</title></rect>
+<rect x="932" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-21: No data</title></rect>
+<rect x="932" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-22: No data</title></rect>
+<rect x="932" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-23: No data</title></rect>
+<rect x="932" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-24: No data</title></rect>
+<rect x="932" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-25: No data</title></rect>
+<rect x="932" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-26: No data</title></rect>
+<rect x="932" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-27: No data</title></rect>
+<rect x="952" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-28: No data</title></rect>
+<rect x="952" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-29: No data</title></rect>
+<rect x="952" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-30: No data</title></rect>
+<rect x="952" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2025-12-31: No data</title></rect>
+<rect x="952" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-01: No data</title></rect>
+<rect x="952" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-02: No data</title></rect>
+<rect x="952" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-03: No data</title></rect>
+<rect x="972" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-04: No data</title></rect>
+<rect x="972" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-05: No data</title></rect>
+<rect x="972" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-06: No data</title></rect>
+<rect x="972" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-07: No data</title></rect>
+<rect x="972" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-08: No data</title></rect>
+<rect x="972" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-09: No data</title></rect>
+<rect x="972" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-10: No data</title></rect>
+<rect x="992" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-11: No data</title></rect>
+<rect x="992" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-12: No data</title></rect>
+<rect x="992" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-13: No data</title></rect>
+<rect x="992" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-14: No data</title></rect>
+<rect x="992" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-15: No data</title></rect>
+<rect x="992" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-16: No data</title></rect>
+<rect x="992" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-17: No data</title></rect>
+<rect x="1012" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-18: No data</title></rect>
+<rect x="1012" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-19: No data</title></rect>
+<rect x="1012" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-20: No data</title></rect>
+<rect x="1012" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-21: No data</title></rect>
+<rect x="1012" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-22: No data</title></rect>
+<rect x="1012" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-23: No data</title></rect>
+<rect x="1012" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-24: No data</title></rect>
+<rect x="1032" y="40" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-25: No data</title></rect>
+<rect x="1032" y="60" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-26: No data</title></rect>
+<rect x="1032" y="80" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-27: No data</title></rect>
+<rect x="1032" y="100" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-28: No data</title></rect>
+<rect x="1032" y="120" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-29: No data</title></rect>
+<rect x="1032" y="140" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-30: No data</title></rect>
+<rect x="1032" y="160" width="16" height="16" rx="3" fill="#ebedf0"><title>2026-01-31: No data</title></rect>
+<rect x="1052" y="40" width="16" height="16" rx="3" fill="#c6e48b"><title>2026-02-01: $27.90</title></rect>
+<rect x="1052" y="60" width="16" height="16" rx="3" fill="#196127"><title>2026-02-02: $136.12</title></rect>
+<rect x="1052" y="80" width="16" height="16" rx="3" fill="#7bc96f"><title>2026-02-03: $59.67</title></rect>
+<rect x="1052" y="100" width="16" height="16" rx="3" fill="#196127"><title>2026-02-04: $123.34</title></rect>
+<rect x="1052" y="120" width="16" height="16" rx="3" fill="#196127"><title>2026-02-05: $120.81</title></rect>
+<rect x="1052" y="140" width="16" height="16" rx="3" fill="#196127"><title>2026-02-06: $134.48</title></rect>
+<rect x="1052" y="160" width="16" height="16" rx="3" fill="#239a3b"><title>2026-02-07: $101.17</title></rect>
+<rect x="1072" y="40" width="16" height="16" rx="3" fill="#196127"><title>2026-02-08: $126.57</title></rect>
+<rect x="1072" y="60" width="16" height="16" rx="3" fill="#239a3b"><title>2026-02-09: $96.71</title></rect>
+<rect x="1072" y="80" width="16" height="16" rx="3" fill="#196127"><title>2026-02-10: $108.43</title></rect>
+<rect x="1072" y="100" width="16" height="16" rx="3" fill="#239a3b"><title>2026-02-11: $74.32</title></rect>
+<rect x="1072" y="120" width="16" height="16" rx="3" fill="#196127"><title>2026-02-12: $141.43</title></rect>
+<rect x="1072" y="140" width="16" height="16" rx="3" fill="#239a3b"><title>2026-02-13: $99.42</title></rect>
+<rect x="1072" y="160" width="16" height="16" rx="3" fill="#239a3b"><title>2026-02-14: $101.46</title></rect>
+<rect x="1092" y="40" width="16" height="16" rx="3" fill="#239a3b"><title>2026-02-15: $94.65</title></rect>
+<rect x="1092" y="60" width="16" height="16" rx="3" fill="#7bc96f"><title>2026-02-16: $69.87</title></rect>
+<rect x="1092" y="80" width="16" height="16" rx="3" fill="#239a3b"><title>2026-02-17: $77.63</title></rect>
+<rect x="1092" y="100" width="16" height="16" rx="3" fill="#196127"><title>2026-02-18: $123.06</title></rect>
+<text x="956" y="205" class="legend-label">Less</text>
+<rect x="996" y="190" width="16" height="16" rx="3" fill="#ebedf0"/>
+<rect x="1016" y="190" width="16" height="16" rx="3" fill="#c6e48b"/>
+<rect x="1036" y="190" width="16" height="16" rx="3" fill="#7bc96f"/>
+<rect x="1056" y="190" width="16" height="16" rx="3" fill="#239a3b"/>
+<rect x="1076" y="190" width="16" height="16" rx="3" fill="#196127"/>
+<text x="1096" y="205" class="legend-label">More</text>
+<text x="52" y="205" class="total">$1,817.04 total (2025~2026)</text>
+
+<line x1="16" y1="220" x2="1116" y2="220" stroke="#d0d7de" stroke-width="1"/>
+<text x="16" y="238" class="stat">Daily avg: <tspan class="stat-val">$100.95</tspan></text>
+<text x="216" y="238" class="stat">Weekly avg: <tspan class="stat-val">$605.68</tspan></text>
+<text x="16" y="256" class="stat">Peak: <tspan class="stat-val">$141.43</tspan> (2026-02-12)</text>
+<text x="216" y="256" class="stat">Active: <tspan class="stat-val">18</tspan> / 365 days</text>
+
+
+<text x="16" y="276" class="section-title">Avg by weekday</text>
+<text x="16" y="302" class="bar-label">Sun</text><rect x="52" y="292" width="189.99389871873095" height="14" rx="3" fill="#239a3b" opacity="0.85"/><text x="247.99389871873095" y="303" class="bar-val">$83.04</text>
+<text x="16" y="324" class="bar-label">Mon</text><rect x="52" y="314" width="230.8572300183038" height="14" rx="3" fill="#196127" opacity="0.85"/><text x="288.85723001830377" y="325" class="bar-val">$100.90</text>
+<text x="16" y="346" class="bar-label">Tue</text><rect x="52" y="336" width="187.408480780964" height="14" rx="3" fill="#239a3b" opacity="0.85"/><text x="245.408480780964" y="347" class="bar-val">$81.91</text>
+<text x="16" y="368" class="bar-label">Wed</text><rect x="52" y="358" width="244.60036607687616" height="14" rx="3" fill="#196127" opacity="0.85"/><text x="302.6003660768762" y="369" class="bar-val">$106.91</text>
+<text x="16" y="390" class="bar-label">Thu</text><rect x="52" y="380" width="300" height="14" rx="3" fill="#196127" opacity="0.85"/><text x="358" y="391" class="bar-val">$131.12</text>
+<text x="16" y="412" class="bar-label">Fri</text><rect x="52" y="402" width="267.57931665649784" height="14" rx="3" fill="#196127" opacity="0.85"/><text x="325.57931665649784" y="413" class="bar-val">$116.95</text>
+<text x="16" y="434" class="bar-label">Sat</text><rect x="52" y="424" width="231.80674191580232" height="14" rx="3" fill="#196127" opacity="0.85"/><text x="289.8067419158023" y="435" class="bar-val">$101.32</text>
+
+</svg>

--- a/scripts/generate-svg.mjs
+++ b/scripts/generate-svg.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+// Load config
+const configPath = resolve(root, "heatmap.config.json");
+const defaults = {
+  colorScheme: "light",
+  theme: "",
+  blockSize: 16,
+  blockMargin: 4,
+  blockRadius: 3,
+  bg: "",
+  textColor: "",
+  start: "",
+  end: "",
+  stats: true,
+  weekday: true,
+};
+const config = existsSync(configPath)
+  ? { ...defaults, ...JSON.parse(readFileSync(configPath, "utf-8")) }
+  : defaults;
+
+const THEMES = {
+  light: ["#ebedf0", "#c6e48b", "#7bc96f", "#239a3b", "#196127"],
+  dark: ["#161b22", "#0e4429", "#006d32", "#26a641", "#39d353"],
+  blue: ["#ebedf0", "#c0ddf9", "#73b3f3", "#3886e1", "#1b4f91"],
+  orange: ["#ebedf0", "#ffdf80", "#ffa742", "#e87d2f", "#ac5219"],
+  pink: ["#ebedf0", "#ffc0cb", "#ff69b4", "#ff1493", "#c71585"],
+};
+const MONTHS = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+const DAY_NAMES = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
+
+const BLOCK = config.blockSize;
+const GAP = config.blockMargin;
+const RADIUS = config.blockRadius;
+const PAD = 16;
+const LABEL_W = 36;
+const HEADER_H = 24;
+
+const scheme = config.colorScheme || "light";
+const colors = THEMES[config.theme || scheme] || THEMES.light;
+const bgColor = config.bg || (scheme === "dark" ? "#0d1117" : "transparent");
+const txtColor = config.textColor || (scheme === "dark" ? "#c9d1d9" : "#24292f");
+const subColor = scheme === "dark" ? "#8b949e" : "#666";
+const showStats = config.stats !== false;
+const showWeekday = config.weekday !== false;
+
+function usd(n) {
+  return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+// Load data
+let data = JSON.parse(readFileSync(resolve(root, "public/data.json"), "utf-8"));
+if (config.start) data = data.filter(d => d.date >= config.start);
+if (config.end) data = data.filter(d => d.date <= config.end);
+
+// Group by weeks
+const weeks = [];
+let cur = [];
+for (const d of data) {
+  if (new Date(d.date).getDay() === 0 && cur.length) { weeks.push(cur); cur = []; }
+  cur.push(d);
+}
+if (cur.length) weeks.push(cur);
+
+const cols = weeks.length;
+const svgW = PAD * 2 + LABEL_W + cols * (BLOCK + GAP) + GAP;
+const svgH = PAD * 2 + HEADER_H + 7 * (BLOCK + GAP) + GAP + 36;
+
+// Month labels
+const monthLabels = [];
+let pm = -1;
+for (let w = 0; w < weeks.length; w++) {
+  const m = new Date(weeks[w][0].date).getMonth();
+  if (m !== pm) { monthLabels.push({ x: PAD + LABEL_W + w * (BLOCK + GAP), label: MONTHS[m] }); pm = m; }
+}
+
+// Rects
+const rects = [];
+for (let w = 0; w < weeks.length; w++) {
+  for (const d of weeks[w]) {
+    const dow = new Date(d.date).getDay();
+    const x = PAD + LABEL_W + w * (BLOCK + GAP);
+    const y = PAD + HEADER_H + dow * (BLOCK + GAP);
+    const cost = d.count > 0 ? `$${d.count.toFixed(2)}` : "No data";
+    rects.push(`<rect x="${x}" y="${y}" width="${BLOCK}" height="${BLOCK}" rx="${RADIUS}" fill="${colors[d.level] || colors[0]}"><title>${d.date}: ${cost}</title></rect>`);
+  }
+}
+
+// Legend
+const lx = svgW - PAD - 5 * (BLOCK + GAP) - 60;
+const ly = PAD + HEADER_H + 7 * (BLOCK + GAP) + 10;
+const lr = colors.map((c, i) => `<rect x="${lx + 40 + i * (BLOCK + GAP)}" y="${ly}" width="${BLOCK}" height="${BLOCK}" rx="${RADIUS}" fill="${c}"/>`).join("\n");
+
+// Total
+const total = data.reduce((s, d) => s + d.count, 0);
+const fy = data[0]?.date.slice(0, 4), ly2 = data[data.length - 1]?.date.slice(0, 4);
+const yl = fy === ly2 ? fy : `${fy}~${ly2}`;
+
+// Stats
+const activeDays = data.filter(d => d.count > 0);
+const dailyAvg = activeDays.length ? total / activeDays.length : 0;
+const peak = activeDays.reduce((max, d) => d.count > max.count ? d : max, { count: 0, date: "-" });
+const weeklyTotals = weeks.map(w => w.reduce((s, d) => s + d.count, 0));
+const activeWeeks = weeklyTotals.filter(t => t > 0);
+const weeklyAvg = activeWeeks.length ? activeWeeks.reduce((s, t) => s + t, 0) / activeWeeks.length : 0;
+
+// Weekday averages
+const weekdayTotals = Array(7).fill(0);
+const weekdayCounts = Array(7).fill(0);
+for (const d of data) {
+  if (d.count > 0) {
+    const dow = new Date(d.date).getDay();
+    weekdayTotals[dow] += d.count;
+    weekdayCounts[dow]++;
+  }
+}
+const weekdayAvgs = weekdayTotals.map((t, i) => weekdayCounts[i] ? t / weekdayCounts[i] : 0);
+const maxWeekdayAvg = Math.max(...weekdayAvgs);
+
+// Extra height
+const STATS_H = showStats ? 50 : 0;
+const WEEKDAY_H = showWeekday ? 180 : 0;
+const totalH = svgH + STATS_H + WEEKDAY_H;
+
+const statsY = ly + BLOCK + 20;
+const weekdayY = statsY + (showStats ? 50 : 10);
+const BAR_W = Math.min(300, svgW - PAD * 2 - 100);
+
+const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${svgW}" height="${totalH}" viewBox="0 0 ${svgW} ${totalH}">
+<rect width="100%" height="100%" fill="${bgColor}" rx="6"/>
+<style>text{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;fill:${txtColor}}.month{font-size:10px}.day{font-size:10px}.legend-label{font-size:10px;fill:${subColor}}.total{font-size:11px;font-weight:600}.stat{font-size:11px;fill:${subColor}}.stat-val{font-size:11px;font-weight:600;fill:${txtColor}}.bar-label{font-size:11px;fill:${subColor}}.bar-val{font-size:10px;fill:${subColor}}.section-title{font-size:12px;font-weight:600}</style>
+${monthLabels.map(m => `<text x="${m.x}" y="${PAD + 14}" class="month">${m.label}</text>`).join("\n")}
+<text x="${PAD}" y="${PAD + HEADER_H + 1 * (BLOCK + GAP) + BLOCK - 2}" class="day">Mon</text>
+<text x="${PAD}" y="${PAD + HEADER_H + 3 * (BLOCK + GAP) + BLOCK - 2}" class="day">Wed</text>
+<text x="${PAD}" y="${PAD + HEADER_H + 5 * (BLOCK + GAP) + BLOCK - 2}" class="day">Fri</text>
+${rects.join("\n")}
+<text x="${lx}" y="${ly + BLOCK - 1}" class="legend-label">Less</text>
+${lr}
+<text x="${lx + 40 + 5 * (BLOCK + GAP)}" y="${ly + BLOCK - 1}" class="legend-label">More</text>
+<text x="${PAD + LABEL_W}" y="${ly + BLOCK - 1}" class="total">${usd(total)} total (${yl})</text>
+${showStats ? `
+<line x1="${PAD}" y1="${statsY - 6}" x2="${svgW - PAD}" y2="${statsY - 6}" stroke="${scheme === "dark" ? "#30363d" : "#d0d7de"}" stroke-width="1"/>
+<text x="${PAD}" y="${statsY + 12}" class="stat">Daily avg: <tspan class="stat-val">${usd(dailyAvg)}</tspan></text>
+<text x="${PAD + 200}" y="${statsY + 12}" class="stat">Weekly avg: <tspan class="stat-val">${usd(weeklyAvg)}</tspan></text>
+<text x="${PAD}" y="${statsY + 30}" class="stat">Peak: <tspan class="stat-val">${usd(peak.count)}</tspan> (${peak.date})</text>
+<text x="${PAD + 200}" y="${statsY + 30}" class="stat">Active: <tspan class="stat-val">${activeDays.length}</tspan> / ${data.length} days</text>
+` : ""}
+${showWeekday ? `
+<text x="${PAD}" y="${weekdayY}" class="section-title">Avg by weekday</text>
+${DAY_NAMES.map((name, i) => {
+  const barY = weekdayY + 14 + i * 22;
+  const barLen = maxWeekdayAvg > 0 ? (weekdayAvgs[i] / maxWeekdayAvg) * BAR_W : 0;
+  const barColor = colors[Math.min(4, Math.ceil((weekdayAvgs[i] / (maxWeekdayAvg || 1)) * 4))];
+  return `<text x="${PAD}" y="${barY + 12}" class="bar-label">${name}</text>` +
+    `<rect x="${PAD + 36}" y="${barY + 2}" width="${barLen}" height="14" rx="3" fill="${barColor}" opacity="0.85"/>` +
+    `<text x="${PAD + 42 + barLen}" y="${barY + 13}" class="bar-val">${usd(weekdayAvgs[i])}</text>`;
+}).join("\n")}
+` : ""}
+</svg>`;
+
+const outPath = resolve(root, "public/heatmap.svg");
+writeFileSync(outPath, svg);
+console.log(`Generated ${outPath} (config: ${configPath})`);

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+const args = process.argv.slice(2);
+const sinceFlag = args.find((a) => a.startsWith("--since"));
+const untilFlag = args.find((a) => a.startsWith("--until"));
+
+let cmd = "npx ccusage@latest daily --json";
+if (sinceFlag) cmd += ` ${sinceFlag}`;
+if (untilFlag) cmd += ` ${untilFlag}`;
+
+console.log(`Running: ${cmd}`);
+const raw = execSync(cmd, { encoding: "utf-8", timeout: 30000 });
+const { daily } = JSON.parse(raw);
+
+const costs = daily.map((d) => d.totalCost);
+const maxCost = Math.max(...costs);
+
+function toLevel(cost) {
+  if (cost === 0 || maxCost === 0) return 0;
+  const ratio = cost / maxCost;
+  if (ratio <= 0.25) return 1;
+  if (ratio <= 0.5) return 2;
+  if (ratio <= 0.75) return 3;
+  return 4;
+}
+
+// Build a map of existing data
+const dataMap = new Map(daily.map((d) => [d.date, d]));
+
+// Fill 365 days (from today back 364 days)
+const today = new Date();
+const activities = [];
+for (let i = 364; i >= 0; i--) {
+  const d = new Date(today);
+  d.setDate(d.getDate() - i);
+  const date = d.toISOString().slice(0, 10);
+  const entry = dataMap.get(date);
+  if (entry) {
+    const cacheTotal = entry.cacheCreationTokens + entry.cacheReadTokens;
+    const cacheHitRate = cacheTotal > 0
+      ? Math.round((entry.cacheReadTokens / cacheTotal) * 100)
+      : 0;
+    activities.push({
+      date,
+      count: Math.round(entry.totalCost * 100) / 100,
+      level: toLevel(entry.totalCost),
+      inputTokens: entry.inputTokens,
+      outputTokens: entry.outputTokens,
+      totalTokens: entry.totalTokens,
+      cacheHitRate,
+      modelsUsed: entry.modelsUsed,
+      modelBreakdowns: entry.modelBreakdowns.map((m) => ({
+        model: m.modelName,
+        cost: Math.round(m.cost * 100) / 100,
+      })),
+    });
+  } else {
+    activities.push({ date, count: 0, level: 0 });
+  }
+}
+
+const outDir = resolve(root, "public");
+mkdirSync(outDir, { recursive: true });
+const outPath = resolve(outDir, "data.json");
+writeFileSync(outPath, JSON.stringify(activities, null, 2));
+console.log(`Generated ${outPath} (${activities.length} days)`);

--- a/scripts/serve-svg.mjs
+++ b/scripts/serve-svg.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+import { createServer } from "node:http";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { URL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+const THEMES = {
+  light: ["#ebedf0", "#c6e48b", "#7bc96f", "#239a3b", "#196127"],
+  dark: ["#161b22", "#0e4429", "#006d32", "#26a641", "#39d353"],
+  blue: ["#ebedf0", "#c0ddf9", "#73b3f3", "#3886e1", "#1b4f91"],
+  orange: ["#ebedf0", "#ffdf80", "#ffa742", "#e87d2f", "#ac5219"],
+  pink: ["#ebedf0", "#ffc0cb", "#ff69b4", "#ff1493", "#c71585"],
+};
+const MONTHS = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+
+function num(v, def) { if (v == null || v === "") return def; const n = Number(v); return isNaN(n) ? def : n; }
+
+function generateSvg(query) {
+  const BLOCK = num(query.get("blockSize"), 16);
+  const GAP = num(query.get("blockMargin"), 4);
+  const RADIUS = num(query.get("blockRadius"), 3);
+  const PAD = 16;
+  const LABEL_W = 36;
+  const HEADER_H = 24;
+  const scheme = query.get("colorScheme") || "light";
+  const colors = THEMES[query.get("theme") || scheme] || THEMES.light;
+  const bgColor = query.get("bg") || (scheme === "dark" ? "#0d1117" : "transparent");
+  const txtColor = query.get("textColor") || (scheme === "dark" ? "#c9d1d9" : "#24292f");
+  const subColor = scheme === "dark" ? "#8b949e" : "#666";
+
+  const dataPath = resolve(root, "public/data.json");
+  let data = JSON.parse(readFileSync(dataPath, "utf-8"));
+  const start = query.get("start"), end = query.get("end");
+  if (start) data = data.filter(d => d.date >= start);
+  if (end) data = data.filter(d => d.date <= end);
+
+  const weeks = []; let cur = [];
+  for (const d of data) {
+    if (new Date(d.date).getDay() === 0 && cur.length) { weeks.push(cur); cur = []; }
+    cur.push(d);
+  }
+  if (cur.length) weeks.push(cur);
+
+  const cols = weeks.length;
+  const svgW = PAD * 2 + LABEL_W + cols * (BLOCK + GAP) + GAP;
+  const svgH = PAD * 2 + HEADER_H + 7 * (BLOCK + GAP) + GAP + 36;
+
+
+  const monthLabels = []; let pm = -1;
+  for (let w = 0; w < weeks.length; w++) {
+    const m = new Date(weeks[w][0].date).getMonth();
+    if (m !== pm) { monthLabels.push({ x: PAD + LABEL_W + w * (BLOCK + GAP), label: MONTHS[m] }); pm = m; }
+  }
+
+  const rects = [];
+  for (let w = 0; w < weeks.length; w++) {
+    for (const d of weeks[w]) {
+      const dow = new Date(d.date).getDay();
+      const x = PAD + LABEL_W + w * (BLOCK + GAP);
+      const y = PAD + HEADER_H + dow * (BLOCK + GAP);
+      const cost = d.count > 0 ? `$${d.count.toFixed(2)}` : "No data";
+      rects.push(`<rect x="${x}" y="${y}" width="${BLOCK}" height="${BLOCK}" rx="${RADIUS}" fill="${colors[d.level] || colors[0]}"><title>${d.date}: ${cost}</title></rect>`);
+    }
+  }
+
+  const lx = svgW - PAD - 5 * (BLOCK + GAP) - 60;
+  const ly = PAD + HEADER_H + 7 * (BLOCK + GAP) + 10;
+  const lr = colors.map((c, i) => `<rect x="${lx + 40 + i * (BLOCK + GAP)}" y="${ly}" width="${BLOCK}" height="${BLOCK}" rx="${RADIUS}" fill="${c}"/>`).join("\n");
+  const total = data.reduce((s, d) => s + d.count, 0);
+  const usd = (n) => `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  const tf = usd(total);
+  const fy = data[0]?.date.slice(0, 4), ly2 = data[data.length - 1]?.date.slice(0, 4);
+  const yl = fy === ly2 ? fy : `${fy}~${ly2}`;
+
+  // Stats
+  const showStats = query.get("stats") !== "false";
+  const showWeekday = query.get("weekday") !== "false";
+  const activeDays = data.filter(d => d.count > 0);
+  const dailyAvg = activeDays.length ? total / activeDays.length : 0;
+  const peak = activeDays.reduce((max, d) => d.count > max.count ? d : max, { count: 0, date: "-" });
+
+  // Weekday averages
+  const DAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  const weekdayTotals = Array(7).fill(0);
+  const weekdayCounts = Array(7).fill(0);
+  for (const d of data) {
+    if (d.count > 0) {
+      const dow = new Date(d.date).getDay();
+      weekdayTotals[dow] += d.count;
+      weekdayCounts[dow]++;
+    }
+  }
+  const weekdayAvgs = weekdayTotals.map((t, i) => weekdayCounts[i] ? t / weekdayCounts[i] : 0);
+  const maxWeekdayAvg = Math.max(...weekdayAvgs);
+
+  // Weekly averages
+  const weeklyTotals = weeks.map(w => w.reduce((s, d) => s + d.count, 0));
+  const activeWeeks = weeklyTotals.filter(t => t > 0);
+  const weeklyAvg = activeWeeks.length ? activeWeeks.reduce((s, t) => s + t, 0) / activeWeeks.length : 0;
+
+  // Extra height
+  const STATS_H = showStats ? 50 : 0;
+  const WEEKDAY_H = showWeekday ? 180 : 0;
+  const totalH = svgH + STATS_H + WEEKDAY_H;
+
+  // Stats section Y
+  const statsY = ly + BLOCK + 20;
+  const weekdayY = statsY + (showStats ? 50 : 10);
+  const BAR_W = Math.min(300, svgW - PAD * 2 - 100);
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${svgW}" height="${totalH}" viewBox="0 0 ${svgW} ${totalH}">
+<rect width="100%" height="100%" fill="${bgColor}" rx="6"/>
+<style>text{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;fill:${txtColor}}.month{font-size:10px}.day{font-size:10px}.legend-label{font-size:10px;fill:${subColor}}.total{font-size:11px;font-weight:600}.stat{font-size:11px;fill:${subColor}}.stat-val{font-size:11px;font-weight:600;fill:${txtColor}}.bar-label{font-size:11px;fill:${subColor}}.bar-val{font-size:10px;fill:${subColor}}.section-title{font-size:12px;font-weight:600}</style>
+${monthLabels.map(m => `<text x="${m.x}" y="${PAD + 14}" class="month">${m.label}</text>`).join("\n")}
+<text x="${PAD}" y="${PAD + HEADER_H + 1 * (BLOCK + GAP) + BLOCK - 2}" class="day">Mon</text>
+<text x="${PAD}" y="${PAD + HEADER_H + 3 * (BLOCK + GAP) + BLOCK - 2}" class="day">Wed</text>
+<text x="${PAD}" y="${PAD + HEADER_H + 5 * (BLOCK + GAP) + BLOCK - 2}" class="day">Fri</text>
+${rects.join("\n")}
+<text x="${lx}" y="${ly + BLOCK - 1}" class="legend-label">Less</text>
+${lr}
+<text x="${lx + 40 + 5 * (BLOCK + GAP)}" y="${ly + BLOCK - 1}" class="legend-label">More</text>
+<text x="${PAD + LABEL_W}" y="${ly + BLOCK - 1}" class="total">${tf} total (${yl})</text>
+${showStats ? `
+<line x1="${PAD}" y1="${statsY - 6}" x2="${svgW - PAD}" y2="${statsY - 6}" stroke="${scheme === "dark" ? "#30363d" : "#d0d7de"}" stroke-width="1"/>
+<text x="${PAD}" y="${statsY + 12}" class="stat">Daily avg: <tspan class="stat-val">${usd(dailyAvg)}</tspan></text>
+<text x="${PAD + 200}" y="${statsY + 12}" class="stat">Weekly avg: <tspan class="stat-val">${usd(weeklyAvg)}</tspan></text>
+<text x="${PAD}" y="${statsY + 30}" class="stat">Peak: <tspan class="stat-val">${usd(peak.count)}</tspan> (${peak.date})</text>
+<text x="${PAD + 200}" y="${statsY + 30}" class="stat">Active: <tspan class="stat-val">${activeDays.length}</tspan> / ${data.length} days</text>
+` : ""}
+${showWeekday ? `
+<text x="${PAD}" y="${weekdayY}" class="section-title">Avg by weekday</text>
+${DAY_NAMES.map((name, i) => {
+  const barY = weekdayY + 14 + i * 22;
+  const barLen = maxWeekdayAvg > 0 ? (weekdayAvgs[i] / maxWeekdayAvg) * BAR_W : 0;
+  const barColor = colors[Math.min(4, Math.ceil((weekdayAvgs[i] / (maxWeekdayAvg || 1)) * 4))];
+  return `<text x="${PAD}" y="${barY + 12}" class="bar-label">${name}</text>` +
+    `<rect x="${PAD + 36}" y="${barY + 2}" width="${barLen}" height="14" rx="3" fill="${barColor}" opacity="0.85"/>` +
+    `<text x="${PAD + 42 + barLen}" y="${barY + 13}" class="bar-val">${usd(weekdayAvgs[i])}</text>`;
+}).join("\n")}
+` : ""}
+</svg>`;
+}
+
+const server = createServer((req, res) => {
+  const url = new URL(req.url, "http://localhost");
+  if (url.pathname === "/api/heatmap" || url.pathname === "/api/heatmap.svg") {
+    res.writeHead(200, { "Content-Type": "image/svg+xml", "Access-Control-Allow-Origin": "*" });
+    res.end(generateSvg(url.searchParams));
+  } else {
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(`<html><body style="padding:2rem;font-family:sans-serif">
+<h2>AI Heatmap SVG API</h2>
+<p><a href="/api/heatmap">Default (light)</a></p>
+<p><a href="/api/heatmap?colorScheme=dark">Dark</a></p>
+<p><a href="/api/heatmap?theme=blue">Blue</a></p>
+<p><a href="/api/heatmap?theme=orange">Orange</a></p>
+<p><a href="/api/heatmap?theme=pink">Pink</a></p>
+<p><a href="/api/heatmap?colorScheme=dark&blockSize=16&blockMargin=4">Dark + Large</a></p>
+<p><a href="/api/heatmap?start=2026-02-01&end=2026-02-18">Feb only</a></p>
+<p><a href="/api/heatmap?stats=false&weekday=false">Heatmap only</a></p>
+<hr/><h3>Preview:</h3>
+<img src="/api/heatmap" style="max-width:100%" /><br/><br/>
+<img src="/api/heatmap?colorScheme=dark" style="max-width:100%" />
+</body></html>`);
+  }
+});
+
+server.listen(3333, () => console.log("SVG API: http://localhost:3333"));

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,94 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html, body {
+  height: 100%;
+  overflow: hidden;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  padding: 1rem;
+}
+
+[data-color-scheme="dark"] {
+  background: #0d1117;
+  color: #c9d1d9;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  overflow: hidden;
+}
+
+h1 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.summary {
+  color: #666;
+  margin-bottom: 1.5rem;
+  font-size: 0.9rem;
+}
+
+[data-color-scheme="dark"] .summary {
+  color: #8b949e;
+}
+
+.error {
+  color: #d73a49;
+  font-weight: 600;
+}
+
+code {
+  background: #f0f0f0;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.85em;
+}
+
+.params-help {
+  margin-top: 2rem;
+  font-size: 0.85rem;
+  color: #666;
+}
+
+[data-color-scheme="dark"] .params-help {
+  color: #8b949e;
+}
+
+.params-help summary {
+  cursor: pointer;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.params-help table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.params-help th,
+.params-help td {
+  border: 1px solid #d0d7de;
+  padding: 6px 12px;
+  text-align: left;
+}
+
+[data-color-scheme="dark"] .params-help th,
+[data-color-scheme="dark"] .params-help td {
+  border-color: #30363d;
+}
+
+.params-help th {
+  background: #f6f8fa;
+}
+
+[data-color-scheme="dark"] .params-help th {
+  background: #161b22;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,225 @@
+import { useEffect, useState } from "react";
+import { ActivityCalendar } from "react-activity-calendar";
+import { Tooltip as ReactTooltip } from "react-tooltip";
+import "react-tooltip/dist/react-tooltip.css";
+
+interface ModelBreakdown {
+  model: string;
+  cost: number;
+}
+
+interface Activity {
+  date: string;
+  count: number;
+  level: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cacheHitRate?: number;
+  modelsUsed?: string[];
+  modelBreakdowns?: ModelBreakdown[];
+}
+
+interface CalendarOptions {
+  blockSize: number;
+  blockMargin: number;
+  blockRadius: number;
+  fontSize: number;
+  hideColorLegend: boolean;
+  hideMonthLabels: boolean;
+  hideTotalCount: boolean;
+  showWeekdayLabels: boolean;
+  weekStart: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  colorScheme: "light" | "dark";
+}
+
+const DEFAULT_OPTIONS: CalendarOptions = {
+  blockSize: 12,
+  blockMargin: 3,
+  blockRadius: 2,
+  fontSize: 12,
+  hideColorLegend: false,
+  hideMonthLabels: false,
+  hideTotalCount: false,
+  showWeekdayLabels: true,
+  weekStart: 0,
+  colorScheme: "light",
+};
+
+function parseOptions(): CalendarOptions {
+  const params = new URLSearchParams(window.location.search);
+  const opts = { ...DEFAULT_OPTIONS };
+
+  const bool = (key: keyof CalendarOptions) => {
+    const v = params.get(key);
+    if (v !== null) {
+      (opts as Record<string, unknown>)[key] = v === "true" || v === "1";
+    }
+  };
+  const num = (key: keyof CalendarOptions) => {
+    const v = params.get(key);
+    if (v !== null && !isNaN(Number(v))) {
+      (opts as Record<string, unknown>)[key] = Number(v);
+    }
+  };
+
+  num("blockSize");
+  num("blockMargin");
+  num("blockRadius");
+  num("fontSize");
+  bool("hideColorLegend");
+  bool("hideMonthLabels");
+  bool("hideTotalCount");
+  bool("showWeekdayLabels");
+  num("weekStart");
+
+  const cs = params.get("colorScheme");
+  if (cs === "light" || cs === "dark") opts.colorScheme = cs;
+
+  return opts;
+}
+
+function commas(n: number) {
+  return n.toLocaleString("en-US");
+}
+
+function formatUSD(n: number) {
+  return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function formatTokens(n: number) {
+  return commas(n);
+}
+
+function shortModel(name: string) {
+  return name
+    .replace("claude-", "")
+    .replace(/-\d{8}$/, "")
+    .replace(/-preview$/, "");
+}
+
+export default function App() {
+  const [data, setData] = useState<Activity[]>([]);
+  const [options] = useState(parseOptions);
+  const [error, setError] = useState<string | null>(null);
+
+  const params = new URLSearchParams(window.location.search);
+  const startDate = params.get("start");
+  const endDate = params.get("end");
+
+  useEffect(() => {
+    fetch("./data.json")
+      .then((r) => {
+        if (!r.ok) throw new Error(`${r.status}`);
+        return r.json();
+      })
+      .then(setData)
+      .catch((e) => setError(`Failed to load data.json: ${e.message}`));
+  }, []);
+
+  if (error) {
+    return (
+      <div className="container">
+        <p className="error">{error}</p>
+        <p>
+          Run <code>npm run generate</code> to create data.json
+        </p>
+      </div>
+    );
+  }
+
+  if (!data.length) {
+    return (
+      <div className="container">
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  const filtered = data.filter((d) => {
+    if (startDate && d.date < startDate) return false;
+    if (endDate && d.date > endDate) return false;
+    return true;
+  });
+
+  const totalCost = filtered.reduce((s, d) => s + d.count, 0);
+  const firstYear = filtered[0]?.date.slice(0, 4);
+  const lastYear = filtered[filtered.length - 1]?.date.slice(0, 4);
+  const yearLabel = firstYear === lastYear ? firstYear : `${firstYear}~${lastYear}`;
+
+  return (
+    <div
+      className="container"
+      data-color-scheme={options.colorScheme}
+    >
+      <h1>AI Usage Heatmap</h1>
+      <p className="summary">
+        Total: {formatUSD(totalCost)} across {filtered.length} days ({yearLabel})
+      </p>
+
+      <ActivityCalendar
+        data={filtered}
+        blockSize={options.blockSize}
+        blockMargin={options.blockMargin}
+        blockRadius={options.blockRadius}
+        fontSize={options.fontSize}
+        hideColorLegend={options.hideColorLegend}
+        hideMonthLabels={options.hideMonthLabels}
+        hideTotalCount={true}
+        showWeekdayLabels={options.showWeekdayLabels}
+        weekStart={options.weekStart}
+        colorScheme={options.colorScheme}
+        labels={{
+          totalCount: "{{count}} USD spent in {{year}}",
+        }}
+        theme={{
+          light: ["#ebedf0", "#c6e48b", "#7bc96f", "#239a3b", "#196127"],
+          dark: ["#161b22", "#0e4429", "#006d32", "#26a641", "#39d353"],
+        }}
+        renderBlock={(block, activity) => {
+          const a = activity as Activity;
+          if (a.count === 0) return block;
+          const lines = [
+            `<strong>${a.date}</strong>`,
+            `Cost: ${formatUSD(a.count)}`,
+            a.inputTokens != null ? `In: ${formatTokens(a.inputTokens)} / Out: ${formatTokens(a.outputTokens ?? 0)}` : "",
+            a.totalTokens ? `Total: ${formatTokens(a.totalTokens)}` : "",
+            a.cacheHitRate != null ? `Cache hit: ${a.cacheHitRate}%` : "",
+            ...(a.modelBreakdowns?.map((m) =>
+              `${shortModel(m.model)}: ${formatUSD(m.cost)}`
+            ) ?? []),
+          ].filter(Boolean);
+          return (
+            <g data-tooltip-id="heatmap-tooltip" data-tooltip-html={lines.join("<br/>")}>
+              {block}
+            </g>
+          );
+        }}
+      />
+      <ReactTooltip id="heatmap-tooltip" />
+
+      <details className="params-help">
+        <summary>Query Parameters</summary>
+        <table>
+          <thead>
+            <tr><th>Param</th><th>Default</th><th>Description</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>blockSize</td><td>14</td><td>Block pixel size</td></tr>
+            <tr><td>blockMargin</td><td>4</td><td>Gap between blocks</td></tr>
+            <tr><td>blockRadius</td><td>2</td><td>Block border radius</td></tr>
+            <tr><td>fontSize</td><td>14</td><td>Label font size</td></tr>
+            <tr><td>hideColorLegend</td><td>false</td><td>Hide color legend</td></tr>
+            <tr><td>hideMonthLabels</td><td>false</td><td>Hide month labels</td></tr>
+            <tr><td>hideTotalCount</td><td>false</td><td>Hide total count</td></tr>
+            <tr><td>showWeekdayLabels</td><td>true</td><td>Show weekday labels</td></tr>
+            <tr><td>weekStart</td><td>0</td><td>Week start day (0=Sun)</td></tr>
+            <tr><td>colorScheme</td><td>light</td><td>light / dark</td></tr>
+            <tr><td>start</td><td>-</td><td>Start date (YYYY-MM-DD)</td></tr>
+            <tr><td>end</td><td>-</td><td>End date (YYYY-MM-DD)</td></tr>
+          </tbody>
+        </table>
+      </details>
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./App.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "npm run deploy",
+  "outputDirectory": "dist",
+  "framework": "vite"
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  base: "./",
+});


### PR DESCRIPTION
Closes #1

## Changes
- React interactive heatmap with tooltips (GitHub Pages deployment)
- Dynamic SVG API endpoint (Vercel serverless function)
- CLI tools: `generate`, `init`, `push`, `update` via `npx ai-heatmap`
- 5 themes: light, dark, blue, orange, pink
- ccusage integration for Claude Code usage data
- GitHub Actions deploy workflow
- Static SVG generation with configurable options (`heatmap.config.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)