### PR TITLE
(#3) fix: post-release fixes and default repo support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-heatmap",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-heatmap",
-      "version": "1.0.0",
+      "version": "1.0.4",
       "license": "ISC",
       "dependencies": {
         "react": "^19.2.4",


### PR DESCRIPTION
Closes #3

## Changes
- Include .gitignore in npm package files
- Use `npm install` instead of `npm ci` in CI workflow
- Skip `generate:svg` if script missing (for init'd repos)
- Add default repo (`{user}/my-ai-heatmap`) for push/update commands
- Update package-lock.json for v1.0.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)