### PR TITLE
(#5) refactor: remove hardcoded username and auto-detect repo owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ GitHub-style heatmap for your AI usage costs. Powered by [ccusage](https://githu
 npx ai-heatmap generate
 
 # Init a new GitHub Pages repo
+npx ai-heatmap init
 npx ai-heatmap init my-ai-heatmap
 
 # Push data to repo
-npx ai-heatmap push --repo owner/my-ai-heatmap
+npx ai-heatmap push
+npx ai-heatmap push --repo my-ai-heatmap
 
 # Generate + push in one step
-npx ai-heatmap update --repo owner/my-ai-heatmap
+npx ai-heatmap update
+npx ai-heatmap update --repo my-ai-heatmap
 ```
 
 ## SVG API (Vercel)

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -24,8 +24,8 @@ Generate options:
 Examples:
   npx ai-heatmap init my-ai-heatmap
   npx ai-heatmap generate --since 20260101
-  npx ai-heatmap push --repo seunggabi/my-ai-heatmap
-  npx ai-heatmap update --repo seunggabi/my-ai-heatmap
+  npx ai-heatmap push --repo my-ai-heatmap
+  npx ai-heatmap update --repo my-ai-heatmap
 `;
 
 switch (command) {

--- a/bin/push.mjs
+++ b/bin/push.mjs
@@ -11,14 +11,18 @@ const args = process.argv.slice(2);
 const repoIdx = args.indexOf("--repo");
 let repo = repoIdx !== -1 ? args[repoIdx + 1] : null;
 
-if (!repo) {
-  try {
-    const owner = execSync("gh api user --jq .login", { encoding: "utf-8" }).trim();
+try {
+  const owner = execSync("gh api user --jq .login", { encoding: "utf-8" }).trim();
+  if (!repo) {
     repo = `${owner}/my-ai-heatmap`;
     console.log(`No --repo specified, using default: ${repo}`);
-  } catch {
+  } else if (!repo.includes("/")) {
+    repo = `${owner}/${repo}`;
+  }
+} catch {
+  if (!repo || !repo.includes("/")) {
     console.error("Usage: ai-heatmap push --repo <owner/repo>");
-    console.error("Example: ai-heatmap push --repo seunggabi/my-ai-heatmap");
+    console.error("Example: ai-heatmap push --repo <owner>/my-ai-heatmap");
     process.exit(1);
   }
 }


### PR DESCRIPTION
Closes #5

## Changes
- Remove hardcoded `seunggabi` from CLI help and error messages
- Auto-prepend owner when `--repo` is passed without `owner/` prefix
- Update README examples to reflect new default repo behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)