### PR TITLE
(#9) refactor: rename default repo pattern to {user}-ai-heatmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ npx ai-heatmap generate
 
 # Init a new GitHub Pages repo
 npx ai-heatmap init
-npx ai-heatmap init my-ai-heatmap
+npx ai-heatmap init {user}-ai-heatmap
 
 # Push data to repo
 npx ai-heatmap push
-npx ai-heatmap push --repo my-ai-heatmap
+npx ai-heatmap push --repo {user}-ai-heatmap
 
 # Generate + push in one step
 npx ai-heatmap update
-npx ai-heatmap update --repo my-ai-heatmap
+npx ai-heatmap update --repo {user}-ai-heatmap
 ```
 
 ## SVG API (Vercel)
@@ -99,7 +99,7 @@ The interactive version with tooltips is deployed via GitHub Pages. Tooltips sho
 All options are controlled via query string:
 
 ```
-https://owner.github.io/my-ai-heatmap/?colorScheme=dark&blockSize=14
+https://owner.github.io/{user}-ai-heatmap/?colorScheme=dark&blockSize=14
 ```
 
 | Parameter | Default | Description |

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -14,8 +14,8 @@ ai-heatmap - AI usage cost heatmap
 Commands:
   init [repo-name]        Create a new heatmap GitHub Pages repo
   generate [options]      Generate data.json from ccusage
-  push [--repo <owner/repo>]  Push data.json to target repo (default: {user}/my-ai-heatmap)
-  update [--repo <owner/repo>]  generate + push combined (default: {user}/my-ai-heatmap)
+  push [--repo <owner/repo>]  Push data.json to target repo (default: {user}/{user}-ai-heatmap)
+  update [--repo <owner/repo>]  generate + push combined (default: {user}/{user}-ai-heatmap)
   deploy                     Deploy to Vercel (SVG API endpoint)
 
 Generate options:
@@ -23,10 +23,10 @@ Generate options:
   --until YYYYMMDD        End date
 
 Examples:
-  npx ai-heatmap init my-ai-heatmap
+  npx ai-heatmap init {user}-ai-heatmap
   npx ai-heatmap generate --since 20260101
-  npx ai-heatmap push --repo my-ai-heatmap
-  npx ai-heatmap update --repo my-ai-heatmap
+  npx ai-heatmap push --repo {user}-ai-heatmap
+  npx ai-heatmap update --repo {user}-ai-heatmap
   npx ai-heatmap deploy
 `;
 

--- a/bin/init.mjs
+++ b/bin/init.mjs
@@ -6,7 +6,12 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const templateRoot = resolve(__dirname, "..");
-const repoName = process.argv[2] || "ai-heatmap";
+let defaultName = "ai-heatmap";
+try {
+  const owner = execSync("gh api user --jq .login", { encoding: "utf-8" }).trim();
+  defaultName = `${owner}-ai-heatmap`;
+} catch {}
+const repoName = process.argv[2] || defaultName;
 const targetDir = resolve(process.cwd(), repoName);
 
 if (existsSync(targetDir)) {
@@ -38,6 +43,7 @@ const pkg = {
   devDependencies: {
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@vercel/node": "^5.6.4",
     "@vitejs/plugin-react": "^5.1.4",
     typescript: "^5.9.3",
     vite: "^7.3.1",
@@ -53,6 +59,7 @@ const filesToCopy = [
   "index.html",
   "vite.config.ts",
   "tsconfig.json",
+  "vercel.json",
   ".gitignore",
 ];
 for (const f of filesToCopy) {
@@ -68,6 +75,13 @@ for (const f of srcFiles) {
     resolve(targetDir, "src", f),
   );
 }
+
+// Copy api/
+mkdirSync(resolve(targetDir, "api"), { recursive: true });
+copyFileSync(
+  resolve(templateRoot, "api/heatmap.ts"),
+  resolve(targetDir, "api/heatmap.ts"),
+);
 
 // Create public/
 mkdirSync(resolve(targetDir, "public"), { recursive: true });

--- a/bin/push.mjs
+++ b/bin/push.mjs
@@ -14,7 +14,7 @@ let repo = repoIdx !== -1 ? args[repoIdx + 1] : null;
 try {
   const owner = execSync("gh api user --jq .login", { encoding: "utf-8" }).trim();
   if (!repo) {
-    repo = `${owner}/my-ai-heatmap`;
+    repo = `${owner}/${owner}-ai-heatmap`;
     console.log(`No --repo specified, using default: ${repo}`);
   } else if (!repo.includes("/")) {
     repo = `${owner}/${repo}`;
@@ -22,7 +22,7 @@ try {
 } catch {
   if (!repo || !repo.includes("/")) {
     console.error("Usage: ai-heatmap push --repo <owner/repo>");
-    console.error("Example: ai-heatmap push --repo <owner>/my-ai-heatmap");
+    console.error("Example: ai-heatmap push --repo <owner>/<owner>-ai-heatmap");
     process.exit(1);
   }
 }

--- a/ccusage-integration/README.md
+++ b/ccusage-integration/README.md
@@ -10,13 +10,13 @@ Add `--heatmap` flag to ccusage that auto-generates and pushes data to a user's 
 
 ```bash
 # One-time setup: create your heatmap repo
-npx ai-heatmap init my-ai-heatmap
+npx ai-heatmap init {user}-ai-heatmap
 
 # Then with ccusage:
-npx ccusage daily --heatmap --heatmap-repo seunggabi/my-ai-heatmap
+npx ccusage daily --heatmap --heatmap-repo {user}/{user}-ai-heatmap
 
 # Or set env var for convenience:
-export CCUSAGE_HEATMAP_REPO=seunggabi/my-ai-heatmap
+export CCUSAGE_HEATMAP_REPO={user}/{user}-ai-heatmap
 npx ccusage daily --heatmap
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "ai-heatmap",
       "version": "1.3.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "react": "^19.2.4",
         "react-activity-calendar": "^3.1.1",


### PR DESCRIPTION
Closes #9

## Changes
- Rename all `my-ai-heatmap` references to `{user}-ai-heatmap` pattern
- Auto-detect GitHub username via `gh api user` for default repo name in `init` and `push`
- Include `api/heatmap.ts` and `vercel.json` in init template for Vercel API support
- Update README.md, cli.mjs, push.mjs, and ccusage-integration/README.md