### PR TITLE
(#11) refactor: simplify CLI to init/update/deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,11 @@ Powered by
 ## Quick Start
 
 ```bash
-# Generate data from local ccusage logs
-npx ai-heatmap generate
-
-# Init a new GitHub Pages repo
+# Init a new heatmap repo (creates repo + generates data + pushes)
 npx ai-heatmap init
 npx ai-heatmap init {user}-ai-heatmap
 
-# Push data to repo
-npx ai-heatmap push
-npx ai-heatmap push --repo {user}-ai-heatmap
-
-# Generate + push in one step
+# Update data (generate + push)
 npx ai-heatmap update
 npx ai-heatmap update --repo {user}-ai-heatmap
 ```
@@ -156,12 +149,7 @@ For the Vercel dynamic API, use query parameters instead (they override config).
 `ccusage` reads Claude Code usage logs from your **local machine**, so data must be generated locally and pushed to the repo.
 
 ```bash
-# Generate + push in one step
 npx ai-heatmap update
-
-# Or manually
-npx ai-heatmap generate
-git add public/data.json && git commit -m "update data" && git push
 ```
 
 For automated updates, use a local cron job or macOS LaunchAgent:

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -12,20 +12,18 @@ const HELP = `
 ai-heatmap - AI usage cost heatmap
 
 Commands:
-  init [repo-name]        Create a new heatmap GitHub Pages repo
-  generate [options]      Generate data.json from ccusage
-  push [--repo <owner/repo>]  Push data.json to target repo (default: {user}/{user}-ai-heatmap)
-  update [--repo <owner/repo>]  generate + push combined (default: {user}/{user}-ai-heatmap)
+  init [repo-name]           Create a new heatmap repo and generate initial data
+  update [--repo <owner/repo>]  Generate data + push to repo (default: {user}/{user}-ai-heatmap)
   deploy                     Deploy to Vercel (SVG API endpoint)
 
-Generate options:
+Update options:
   --since YYYYMMDD        Start date
   --until YYYYMMDD        End date
+  --repo <owner/repo>     Target repo (default: auto-detect)
 
 Examples:
-  npx ai-heatmap init {user}-ai-heatmap
-  npx ai-heatmap generate --since 20260101
-  npx ai-heatmap push --repo {user}-ai-heatmap
+  npx ai-heatmap init
+  npx ai-heatmap update
   npx ai-heatmap update --repo {user}-ai-heatmap
   npx ai-heatmap deploy
 `;
@@ -33,16 +31,6 @@ Examples:
 switch (command) {
   case "init": {
     const script = resolve(__dirname, "init.mjs");
-    execSync(`node ${script} ${args.join(" ")}`, { stdio: "inherit" });
-    break;
-  }
-  case "generate": {
-    const script = resolve(root, "scripts/generate.mjs");
-    execSync(`node ${script} ${args.join(" ")}`, { stdio: "inherit" });
-    break;
-  }
-  case "push": {
-    const script = resolve(__dirname, "push.mjs");
     execSync(`node ${script} ${args.join(" ")}`, { stdio: "inherit" });
     break;
   }

--- a/bin/init.mjs
+++ b/bin/init.mjs
@@ -126,11 +126,20 @@ try {
   console.log("Push manually: git remote add origin <url> && git push -u origin main");
 }
 
+// Generate and push data
+console.log("\nGenerating and pushing heatmap data...");
+try {
+  const genScript = resolve(templateRoot, "scripts/generate.mjs");
+  const pushScript = resolve(__dirname, "push.mjs");
+  execSync(`node ${genScript}`, { stdio: "inherit" });
+  execSync(`node ${pushScript} --repo ${repoName}`, { stdio: "inherit" });
+} catch {
+  console.log("Data generation/push skipped. Run 'npx ai-heatmap update' later.");
+}
+
 console.log(`
-Done! Next steps:
+Done! Your heatmap repo is ready:
   cd ${repoName}
   npm install
-  npm run generate        # Generate data from ccusage
   npm run dev             # Preview locally
-  git push                # Deploy to GitHub Pages
 `);


### PR DESCRIPTION
Closes #11

## Changes
- Remove `generate` and `push` as standalone CLI commands
- `init` now automatically runs generate + push after repo creation
- CLI simplified to 3 commands: `init`, `update`, `deploy`
- Updated README Quick Start and Data Update sections