### PR TITLE
(#15) feat: load heatmap.config.json in interactive React app

### DIFF
--- a/bin/init.mjs
+++ b/bin/init.mjs
@@ -85,8 +85,12 @@ copyFileSync(
   resolve(targetDir, "api/heatmap.ts"),
 );
 
-// Create public/
+// Create public/ with config
 mkdirSync(resolve(targetDir, "public"), { recursive: true });
+copyFileSync(
+  resolve(templateRoot, "heatmap.config.json"),
+  resolve(targetDir, "public/heatmap.config.json"),
+);
 
 // GitHub Actions workflow
 const workflowDir = resolve(targetDir, ".github/workflows");

--- a/public/heatmap.config.json
+++ b/public/heatmap.config.json
@@ -1,0 +1,18 @@
+{
+  "colorScheme": "light",
+  "theme": "",
+  "blockSize": 16,
+  "blockMargin": 4,
+  "blockRadius": 3,
+  "bg": "",
+  "textColor": "",
+  "start": "",
+  "end": "",
+  "stats": {
+    "dailyAvg": true,
+    "weeklyAvg": true,
+    "peak": true,
+    "activeDays": true
+  },
+  "weekday": true
+}


### PR DESCRIPTION
Closes #15

## Changes
- React app (GitHub Pages) now loads `heatmap.config.json` as default settings
- URL query parameters still override config values
- Init template copies config to `public/` for browser access
- Supports: colorScheme, blockSize, blockMargin, blockRadius, start, end