### PR TITLE
(#17) feat: add stats section to interactive React heatmap

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -52,6 +52,38 @@ code {
   font-size: 0.85em;
 }
 
+.stats {
+  display: flex;
+  gap: 2rem;
+  margin-top: 1.5rem;
+  padding: 1rem 0;
+  border-top: 1px solid #d0d7de;
+}
+
+[data-color-scheme="dark"] .stats {
+  border-top-color: #30363d;
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.stat-value {
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.stat-label {
+  font-size: 0.75rem;
+  color: #666;
+  margin-top: 2px;
+}
+
+[data-color-scheme="dark"] .stat-label {
+  color: #8b949e;
+}
+
 .params-help {
   margin-top: 2rem;
   font-size: 0.85rem;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -169,7 +169,12 @@ export default function App() {
     return true;
   });
 
+  const activeDays = filtered.filter((d) => d.count > 0);
   const totalCost = filtered.reduce((s, d) => s + d.count, 0);
+  const dailyAvg = activeDays.length ? totalCost / activeDays.length : 0;
+  const weeks = Math.max(1, Math.ceil(filtered.length / 7));
+  const weeklyAvg = totalCost / weeks;
+  const peak = activeDays.reduce((max, d) => (d.count > max.count ? d : max), activeDays[0]);
   const firstYear = filtered[0]?.date.slice(0, 4);
   const lastYear = filtered[filtered.length - 1]?.date.slice(0, 4);
   const yearLabel = firstYear === lastYear ? firstYear : `${firstYear}~${lastYear}`;
@@ -224,6 +229,27 @@ export default function App() {
         }}
       />
       <ReactTooltip id="heatmap-tooltip" />
+
+      {activeDays.length > 0 && (
+        <div className="stats">
+          <div className="stat-item">
+            <span className="stat-value">{formatUSD(dailyAvg)}</span>
+            <span className="stat-label">Daily Avg</span>
+          </div>
+          <div className="stat-item">
+            <span className="stat-value">{formatUSD(weeklyAvg)}</span>
+            <span className="stat-label">Weekly Avg</span>
+          </div>
+          <div className="stat-item">
+            <span className="stat-value">{formatUSD(peak?.count ?? 0)}</span>
+            <span className="stat-label">Peak ({peak?.date})</span>
+          </div>
+          <div className="stat-item">
+            <span className="stat-value">{activeDays.length}</span>
+            <span className="stat-label">Active Days</span>
+          </div>
+        </div>
+      )}
 
       <details className="params-help">
         <summary>Query Parameters</summary>


### PR DESCRIPTION
Closes #17

## Changes
- Add stats section showing Daily Avg, Weekly Avg, Peak day, Active Days
- Styled with flexbox layout, supports light/dark color scheme
- Stats calculated from filtered data (respects date range)