### PR TITLE
(#19) feat: support all heatmap.config.json options with query string control

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -84,6 +84,69 @@ code {
   color: #8b949e;
 }
 
+.weekday-chart {
+  margin-top: 1.5rem;
+  padding: 1rem 0;
+  border-top: 1px solid #d0d7de;
+}
+
+[data-color-scheme="dark"] .weekday-chart {
+  border-top-color: #30363d;
+}
+
+.weekday-chart h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.weekday-bars {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.weekday-bar-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+}
+
+.weekday-bar-wrapper {
+  width: 100%;
+  height: 80px;
+  display: flex;
+  align-items: flex-end;
+}
+
+.weekday-bar {
+  width: 100%;
+  min-height: 2px;
+  border-radius: 2px 2px 0 0;
+  transition: height 0.3s ease;
+}
+
+.weekday-label {
+  font-size: 0.7rem;
+  margin-top: 4px;
+  color: #666;
+}
+
+[data-color-scheme="dark"] .weekday-label {
+  color: #8b949e;
+}
+
+.weekday-value {
+  font-size: 0.65rem;
+  color: #999;
+  margin-top: 1px;
+}
+
+[data-color-scheme="dark"] .weekday-value {
+  color: #6e7681;
+}
+
 .params-help {
   margin-top: 2rem;
   font-size: 0.85rem;


### PR DESCRIPTION
Closes #19

## Changes
- Support all config fields: theme, bg, textColor, stats (individual toggles), weekday chart
- 5 color themes: light, dark, blue, orange, pink
- Stats individually toggleable via query string (stats=false, dailyAvg=false, etc.)
- Weekday average bar chart with theme-colored bars
- bg/textColor applied as inline styles
- Updated query parameters help table