### PR TITLE
(#21) fix: format total cost, add weekday to tooltip, widen container

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -20,7 +20,7 @@ body {
 }
 
 .container {
-  max-width: 960px;
+  max-width: 1200px;
   margin: 0 auto;
   overflow: hidden;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -183,6 +183,7 @@ function shortModel(name: string) {
 }
 
 const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const DAY_SHORT = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
 
 export default function App() {
   const [data, setData] = useState<Activity[]>([]);
@@ -293,12 +294,12 @@ export default function App() {
         fontSize={options.fontSize}
         hideColorLegend={options.hideColorLegend}
         hideMonthLabels={options.hideMonthLabels}
-        hideTotalCount={true}
+        hideTotalCount={options.hideTotalCount}
         showWeekdayLabels={options.showWeekdayLabels}
         weekStart={options.weekStart}
         colorScheme={options.colorScheme}
         labels={{
-          totalCount: "{{count}} USD spent in {{year}}",
+          totalCount: `${formatUSD(totalCost)} spent in {{year}}`,
         }}
         theme={{
           light: themeColors,
@@ -308,7 +309,7 @@ export default function App() {
           const a = activity as Activity;
           if (a.count === 0) return block;
           const lines = [
-            `<strong>${a.date}</strong>`,
+            `<strong>${a.date} (${DAY_SHORT[new Date(a.date).getDay()]})</strong>`,
             `Cost: ${formatUSD(a.count)}`,
             a.inputTokens != null ? `In: ${formatTokens(a.inputTokens)} / Out: ${formatTokens(a.outputTokens ?? 0)}` : "",
             a.totalTokens ? `Total: ${formatTokens(a.totalTokens)}` : "",


### PR DESCRIPTION
Closes #21

## Changes
- Format total cost to 2 decimal places (was showing floating point like `1878.6800000000005`)
- Add weekday label to tooltip: `yyyy-MM-dd (MON)` format
- Widen container max-width from 960px to 1200px