### PR TITLE
(#23) docs: add badges, star history, sponsor, and author to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # AI Heatmap
 
-GitHub-style heatmap for your AI usage costs. 
-Powered by 
-[ccusage](https://github.com/ryoppippi/ccusage)
-[react-activity-calendar](https://github.com/grubersjoe/react-activity-calendar).
+[![npm version](https://img.shields.io/npm/v/ai-heatmap?color=cb3837&logo=npm)](https://www.npmjs.com/package/ai-heatmap)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![GitHub Stars](https://img.shields.io/github/stars/seunggabi/ai-heatmap?style=social)](https://github.com/seunggabi/ai-heatmap/stargazers)
+[![Node.js](https://img.shields.io/badge/Node.js-20-339933?logo=node.js)](https://nodejs.org)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript)](https://www.typescriptlang.org)
+[![React](https://img.shields.io/badge/React-19-61DAFB?logo=react)](https://react.dev)
+
+GitHub-style heatmap for your AI usage costs.
+Powered by [ccusage](https://github.com/ryoppippi/ccusage) + [react-activity-calendar](https://github.com/grubersjoe/react-activity-calendar).
 
 ## Preview
 
@@ -209,6 +214,29 @@ ai-heatmap/
   public/data.json            # Generated activity data
 ```
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=seunggabi/ai-heatmap&type=Date)](https://star-history.com/#seunggabi/ai-heatmap&Date)
+
+## Sponsor
+
+If this project helps you, consider supporting it:
+
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-❤️-ea4aaa?logo=github)](https://github.com/sponsors/seunggabi)
+
 ## License
 
-MIT
+MIT License - see [LICENSE](LICENSE) file for details
+
+Copyright (c) 2026 seunggabi
+
+## Author
+
+**seunggabi**
+
+- GitHub: [@seunggabi](https://github.com/seunggabi)
+- Repository: [ai-heatmap](https://github.com/seunggabi/ai-heatmap)
+
+---
+
+Made with ❤️ using React, TypeScript, and Vite

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-heatmap",
-  "version": "1.3.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-heatmap",
-      "version": "1.3.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "react": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-heatmap",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "AI usage cost heatmap powered by ccusage + react-activity-calendar",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Closes #23

## Changes
- Add npm version, license, stars, Node.js, TypeScript, React badges at top
- Add Star History chart section
- Add Sponsor section with GitHub Sponsors link
- Add Author section with GitHub profile link
- Update License section with copyright notice
- Add footer