### PR TITLE
(#25) feat: improve deploy detection, year range display, and Vite SVG API proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Powered by [ccusage](https://github.com/ryoppippi/ccusage) + [react-activity-cal
 ## Preview
 
 <!-- Replace YOUR_VERCEL_DOMAIN with your actual Vercel deployment URL -->
-![AI Heatmap](https://YOUR_VERCEL_DOMAIN/api/heatmap)
+![AI Heatmap](https://seunggabi-ai-heatmap/api/heatmap)
 
 ### Variations
 
@@ -45,7 +45,7 @@ npx ai-heatmap update --repo {user}-ai-heatmap
 
 ## SVG API (Vercel)
 
-Deploy this repo to Vercel for a dynamic SVG endpoint. Embed it in any README:
+~~Deploy~~ this repo to Vercel for a dynamic SVG endpoint. Embed it in any README:
 
 ```markdown
 ![AI Heatmap](https://your-app.vercel.app/api/heatmap)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-heatmap",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-heatmap",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "MIT",
       "dependencies": {
         "react": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-heatmap",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "AI usage cost heatmap powered by ccusage + react-activity-calendar",
   "type": "module",
   "bin": {

--- a/src/App.css
+++ b/src/App.css
@@ -20,7 +20,7 @@ body {
 }
 
 .container {
-  max-width: 1200px;
+  max-width: 1100px;
   margin: 0 auto;
   overflow: hidden;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -283,7 +283,7 @@ export default function App() {
     >
       <h1>AI Usage Heatmap</h1>
       <p className="summary">
-        Total: {formatUSD(totalCost)} across {filtered.length} days ({yearLabel})
+        💰 Total: {formatUSD(totalCost)} across {filtered.length} days ({yearLabel})
       </p>
 
       <ActivityCalendar
@@ -299,7 +299,7 @@ export default function App() {
         weekStart={options.weekStart}
         colorScheme={options.colorScheme}
         labels={{
-          totalCount: `${formatUSD(totalCost)} spent in {{year}}`,
+          totalCount: `💰 ${formatUSD(totalCost)} spent in ${yearLabel}`,
         }}
         theme={{
           light: themeColors,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,27 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      name: "svg-api-dev",
+      configureServer() {
+        const script = resolve(__dirname, "scripts/serve-svg.mjs");
+        const child = spawn("node", [script], { stdio: "inherit" });
+        process.on("exit", () => child.kill());
+      },
+    },
+  ],
   base: "./",
+  server: {
+    proxy: {
+      "/api/heatmap": "http://localhost:3333",
+    },
+  },
 });


### PR DESCRIPTION
Closes #25

## Changes
- Deploy command auto-detects `{user}-ai-heatmap` directory instead of deploying npm package path
- Year label shows range (`2025~2026`) when data spans multiple years
- Add 💰 emoji to cost display
- Container max-width 1200px → 1100px
- Vite dev server auto-starts SVG API server and proxies `/api/heatmap`