### PR TITLE
(#27) fix: change Vercel buildCommand from deploy to build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-heatmap",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-heatmap",
-      "version": "1.9.2",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "react": "^19.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-heatmap",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "description": "AI usage cost heatmap powered by ccusage + react-activity-calendar",
   "type": "module",
   "bin": {

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "npm run deploy",
+  "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "framework": "vite"
 }


### PR DESCRIPTION
## Summary
- Change `vercel.json` `buildCommand` from `npm run deploy` to `npm run build`
- The `deploy` script includes `generate` steps that fail in Vercel's build environment
- Bump version to v1.10.0

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)