### PR TITLE
(#29) docs: add --yes flag to cron example for non-interactive npx usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,10 @@ For automated updates, use a local cron job or macOS LaunchAgent:
 
 ```bash
 # crontab -e (runs daily at midnight)
-0 0 * * * npx ai-heatmap update
+0 0 * * * npx --yes ai-heatmap@latest update
 ```
+
+> `--yes` skips the npx install prompt, required for non-interactive environments like cron.
 
 ## Upgrade
 


### PR DESCRIPTION
## Summary
- Update cron example to use `npx --yes ai-heatmap@latest update` to skip install prompt
- Add note explaining `--yes` flag is required for non-interactive environments like cron

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)