### PR TITLE
(#31) feat: git pull before Vercel deploy, improve totalCount label, update deploy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ npx --yes ai-heatmap@latest update
 
 1. Import this repo on [vercel.com](https://vercel.com)
 2. Deploy (zero config — `vercel.json` included)
-3. Use the deployed URL for dynamic SVG embeds
+3. Make public: Project Settings > Deployment Protection > Vercel Authentication > **OFF**
+4. Use the deployed URL for dynamic SVG embeds
 
 ## Local Development
 

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -75,6 +75,11 @@ switch (command) {
       } catch {}
     }
     console.log(`Deploying from ${deployDir}...`);
+    try {
+      execSync("git pull", { cwd: deployDir, stdio: "inherit" });
+    } catch {
+      console.log("git pull skipped (not a git repo or no remote)");
+    }
     execSync(`vercel --prod`, {
       cwd: deployDir,
       stdio: "inherit",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -282,10 +282,6 @@ export default function App() {
       style={containerStyle}
     >
       <h1>AI Usage Heatmap</h1>
-      <p className="summary">
-        💰 Total: {formatUSD(totalCost)} across {filtered.length} days ({yearLabel})
-      </p>
-
       <ActivityCalendar
         data={filtered}
         blockSize={options.blockSize}
@@ -299,7 +295,7 @@ export default function App() {
         weekStart={options.weekStart}
         colorScheme={options.colorScheme}
         labels={{
-          totalCount: `💰 ${formatUSD(totalCost)} spent in ${yearLabel}`,
+          totalCount: `💰 Total: ${formatUSD(totalCost)} across ${filtered.length} days (${yearLabel})`,
         }}
         theme={{
           light: themeColors,


### PR DESCRIPTION
## Summary
- Add `git pull` before `vercel --prod` to sync latest data.json from repo
- Consolidate totalCount label into ActivityCalendar, remove duplicate summary paragraph
- Add Vercel Deployment Protection disable step to README

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)