### PR TITLE
(#43) chore: change default colorScheme to dark

### DIFF
--- a/public/heatmap.config.json
+++ b/public/heatmap.config.json
@@ -1,5 +1,5 @@
 {
-  "colorScheme": "light",
+  "colorScheme": "dark",
   "theme": "",
   "blockSize": 16,
   "blockMargin": 4,


### PR DESCRIPTION
## Summary
- Change default `colorScheme` from `light` to `dark` in `heatmap.config.json`

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)