### PR TITLE
(#51) fix: copy heatmap.config.json in init instead of hardcoding defaults

### DIFF
--- a/bin/init.mjs
+++ b/bin/init.mjs
@@ -99,22 +99,9 @@ copyFileSync(
 
 // Create public/ with config
 mkdirSync(resolve(targetDir, "public"), { recursive: true });
-const defaultConfig = {
-  colorScheme: "light",
-  theme: "",
-  blockSize: 16,
-  blockMargin: 4,
-  blockRadius: 3,
-  bg: "",
-  textColor: "",
-  start: "",
-  end: "",
-  stats: true,
-  weekday: true,
-};
-writeFileSync(
+copyFileSync(
+  resolve(templateRoot, "public/heatmap.config.json"),
   resolve(targetDir, "public/heatmap.config.json"),
-  JSON.stringify(defaultConfig, null, 2),
 );
 
 // README.md

--- a/public/heatmap.config.json
+++ b/public/heatmap.config.json
@@ -8,11 +8,6 @@
   "textColor": "",
   "start": "",
   "end": "",
-  "stats": {
-    "dailyAvg": true,
-    "weeklyAvg": true,
-    "peak": true,
-    "activeDays": true
-  },
+  "stats": true,
   "weekday": true
 }


### PR DESCRIPTION
## Summary
- `bin/init.mjs`: copy `public/heatmap.config.json` instead of hardcoding defaults (was `colorScheme: "light"`, now inherits `"dark"`)
- `public/heatmap.config.json`: align `stats` field to `boolean` matching `svg-builder.ts` implementation

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)