### PR TITLE
(#53) fix: add dark colorScheme to default heatmap URL in init

### DIFF
--- a/bin/init.mjs
+++ b/bin/init.mjs
@@ -134,7 +134,7 @@ readmeLines.push(
   "",
   "## Dynamic SVG (by Vercel)",
   "",
-  `![AI Heatmap](https://${repoName}.vercel.app/api/heatmap?theme=blue)`,
+  `![AI Heatmap](https://${repoName}.vercel.app/api/heatmap?theme=blue&colorScheme=dark)`,
   "",
   "```bash",
   "npx --yes ai-heatmap@latest deploy",


### PR DESCRIPTION
## Summary
- Add `colorScheme=dark` query parameter to the default heatmap SVG URL generated in init script README

Closes #53

## Test plan
- [ ] Run `npx ai-heatmap init` and verify the generated README contains `&colorScheme=dark` in the heatmap URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)