### PR TITLE
fix: npx hangs in cron due to missing --yes flag and short timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ npx ai-heatmap update
 For automated updates, use a local cron job or macOS LaunchAgent:
 
 ```bash
-0 0 * * * npx --yes ai-heatmap@latest update
+0 0 * * * npx --yes ai-heatmap@latest update &
 ```
 
 ## Upgrade

--- a/bin/init.mjs
+++ b/bin/init.mjs
@@ -129,7 +129,7 @@ readmeLines.push(
   "### Cron (daily update)",
   "",
   "```bash",
-  "0 0 * * * npx --yes ai-heatmap@latest update",
+  "0 0 * * * npx --yes ai-heatmap@latest update &",
   "```",
   "",
   "## Dynamic SVG (by Vercel)",

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -11,12 +11,12 @@ const args = process.argv.slice(2);
 const sinceFlag = args.find((a) => a.startsWith("--since"));
 const untilFlag = args.find((a) => a.startsWith("--until"));
 
-let cmd = "npx ccusage@latest daily --json";
+let cmd = "npx --yes ccusage@latest daily --json";
 if (sinceFlag) cmd += ` ${sinceFlag}`;
 if (untilFlag) cmd += ` ${untilFlag}`;
 
 console.log(`Running: ${cmd}`);
-const raw = execSync(cmd, { encoding: "utf-8", timeout: 30000 });
+const raw = execSync(cmd, { encoding: "utf-8", timeout: 300000 });
 const { daily } = JSON.parse(raw);
 
 const costs = daily.map((d) => d.totalCost);


### PR DESCRIPTION
## Summary
- Add `--yes` flag to inner `npx ccusage@latest` call to prevent interactive prompt hang in cron
- Increase execSync timeout from 30s to 300s for cron environments (package download + git scan)
- Update cron examples with `&` for background execution

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)