### PR TITLE
docs: remove unnecessary & from cron examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ npx ai-heatmap update
 For automated updates, use a local cron job or macOS LaunchAgent:
 
 ```bash
-0 0 * * * npx --yes ai-heatmap@latest update &
+0 0 * * * npx --yes ai-heatmap@latest update
 ```
 
 ## Upgrade

--- a/bin/init.mjs
+++ b/bin/init.mjs
@@ -129,7 +129,7 @@ readmeLines.push(
   "### Cron (daily update)",
   "",
   "```bash",
-  "0 0 * * * npx --yes ai-heatmap@latest update &",
+  "0 0 * * * npx --yes ai-heatmap@latest update",
   "```",
   "",
   "## Dynamic SVG (by Vercel)",


### PR DESCRIPTION
## Summary
- Remove trailing `&` from cron command examples in README and init template
- Cron already runs jobs in the background, so `&` is unnecessary

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)