### PR TITLE
(#63) feat: cross-platform machine ID and GitHub API sync for multi-machine data

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,11 +1,33 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import os from "node:os";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, "..");
+
+function getMachineName() {
+  try {
+    if (process.platform === "darwin") {
+      const serial = execSync(
+        "ioreg -rd1 -c IOPlatformExpertDevice | awk '/IOPlatformSerialNumber/ {print $NF}' | tr -d '\"'",
+        { encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] },
+      ).trim();
+      if (serial) return serial;
+    } else if (process.platform === "linux") {
+      const id = readFileSync("/etc/machine-id", "utf-8").trim();
+      if (id) return id.slice(0, 12);
+    } else if (process.platform === "win32") {
+      const uuid = execSync("wmic csproduct get UUID /value", {
+        encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"],
+      }).match(/UUID=([^\r\n]+)/)?.[1]?.trim();
+      if (uuid) return uuid.replace(/[^a-zA-Z0-9]/g, "").slice(0, 12);
+    }
+  } catch {}
+  return os.hostname().replace(/[^a-zA-Z0-9_-]/g, "_");
+}
 
 const [command, ...args] = process.argv.slice(2);
 
@@ -22,7 +44,7 @@ Commands:
 
 Options:
   --repo <name>           Target repo (default: {user}-ai-heatmap)
-  --name <machine>        Machine name for per-device data file (update only)
+  --name <machine>        Machine name for per-device data file (default: serial number)
   --since YYYYMMDD        Start date (update only)
   --until YYYYMMDD        End date (update only)
 
@@ -30,6 +52,7 @@ Examples:
   npx ai-heatmap init
   npx ai-heatmap init --repo my-heatmap
   npx ai-heatmap update
+  npx ai-heatmap update --name=mac
   npx ai-heatmap update --repo owner/repo-name
   npx ai-heatmap delete
   npx ai-heatmap deploy
@@ -38,6 +61,45 @@ Examples:
 function getArg(flag) {
   const idx = args.indexOf(flag);
   return idx !== -1 && args[idx + 1] ? args[idx + 1] : null;
+}
+
+function resolveRepo(repoArg) {
+  try {
+    const owner = execSync("gh api user --jq .login", { encoding: "utf-8" }).trim();
+    if (!repoArg) return `${owner}/${owner}-ai-heatmap`;
+    if (!repoArg.includes("/")) return `${owner}/${repoArg}`;
+    return repoArg;
+  } catch {
+    if (repoArg && repoArg.includes("/")) return repoArg;
+    console.error("Could not determine repo. Use --repo <owner/repo>");
+    process.exit(1);
+  }
+}
+
+function pushFile(repo, repoPath, localPath) {
+  const content = readFileSync(localPath, "utf-8");
+  const base64 = Buffer.from(content).toString("base64");
+
+  let sha = "";
+  try {
+    sha = execSync(
+      `gh api repos/${repo}/contents/${repoPath} --jq .sha`,
+      { encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] },
+    ).trim();
+  } catch { /* file doesn't exist yet */ }
+
+  const payload = {
+    message: `Update ${repoPath} (${new Date().toISOString().slice(0, 10)})`,
+    content: base64,
+  };
+  if (sha) payload.sha = sha;
+
+  const payloadStr = JSON.stringify(JSON.stringify(payload));
+  execSync(
+    `echo ${payloadStr} | gh api repos/${repo}/contents/${repoPath} -X PUT --input -`,
+    { stdio: ["pipe", "inherit", "inherit"] },
+  );
+  console.log(`  Pushed ${repoPath} to ${repo}`);
 }
 
 switch (command) {
@@ -49,13 +111,57 @@ switch (command) {
   }
   case "update": {
     const genScript = resolve(root, "scripts/generate.mjs");
-    const pushScript = resolve(__dirname, "push.mjs");
+    const outDir = resolve(root, "public");
     const genArgs = args.filter(
       (a) => a.startsWith("--since") || a.startsWith("--until") || a.startsWith("--name"),
     );
-    const pushArgs = args.filter((a) => a.startsWith("--repo"));
+
+    const repo = resolveRepo(getArg("--repo"));
+
+    // 머신 이름 결정 (generate.mjs와 동일한 로직)
+    const nameFlag = genArgs.find((a) => a.startsWith("--name="));
+    const machineName = nameFlag
+      ? nameFlag.slice("--name=".length)
+      : getMachineName();
+
+    // 1. GitHub API로 다른 컴퓨터의 data-*.json 파일들을 로컬에 다운로드
+    console.log(`Fetching machine data files from ${repo}...`);
+    mkdirSync(outDir, { recursive: true });
+    try {
+      const raw = execSync(
+        `gh api repos/${repo}/contents/public --jq '[.[] | select(.name | test("^data-.+\\.json$"))]'`,
+        { encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] },
+      );
+      const files = JSON.parse(raw);
+      for (const file of files) {
+        // 현재 컴퓨터 파일은 generate에서 새로 생성하므로 건너뜀
+        if (file.name === `data-${machineName}.json`) continue;
+        const decoded = Buffer.from(file.content.replace(/\n/g, ""), "base64").toString("utf-8");
+        writeFileSync(resolve(outDir, file.name), decoded);
+        console.log(`  Fetched ${file.name}`);
+      }
+    } catch {
+      console.log("  No existing machine data files found (first run).");
+    }
+
+    // 2. generate: 이 컴퓨터 데이터 수집 + 모든 data-*.json 합산 → data.json 생성
     execSync(`node ${genScript} ${genArgs.join(" ")}`, { stdio: "inherit" });
-    execSync(`node ${pushScript} ${pushArgs.join(" ")}`, { stdio: "inherit" });
+
+    // 3. data-{name}.json push (이 컴퓨터 개별 파일)
+    const machineFile = `data-${machineName}.json`;
+    const machineFilePath = resolve(outDir, machineFile);
+    if (existsSync(machineFilePath)) {
+      console.log(`Pushing machine data file...`);
+      pushFile(repo, `public/${machineFile}`, machineFilePath);
+    }
+
+    // 4. data.json push (합산 결과)
+    const dataPath = resolve(outDir, "data.json");
+    if (existsSync(dataPath)) {
+      console.log(`Pushing merged data.json...`);
+      pushFile(repo, "public/data.json", dataPath);
+    }
+
     break;
   }
   case "delete": {

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -8,13 +8,34 @@ import os from "node:os";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, "..");
 
+function getMachineName() {
+  try {
+    if (process.platform === "darwin") {
+      const serial = execSync(
+        "ioreg -rd1 -c IOPlatformExpertDevice | awk '/IOPlatformSerialNumber/ {print $NF}' | tr -d '\"'",
+        { encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] },
+      ).trim();
+      if (serial) return serial;
+    } else if (process.platform === "linux") {
+      const id = readFileSync("/etc/machine-id", "utf-8").trim();
+      if (id) return id.slice(0, 12);
+    } else if (process.platform === "win32") {
+      const uuid = execSync("wmic csproduct get UUID /value", {
+        encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"],
+      }).match(/UUID=([^\r\n]+)/)?.[1]?.trim();
+      if (uuid) return uuid.replace(/[^a-zA-Z0-9]/g, "").slice(0, 12);
+    }
+  } catch {}
+  return os.hostname().replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
 const args = process.argv.slice(2);
 const sinceFlag = args.find((a) => a.startsWith("--since"));
 const untilFlag = args.find((a) => a.startsWith("--until"));
 const nameFlag = args.find((a) => a.startsWith("--name="));
 const machineName = nameFlag
   ? nameFlag.slice("--name=".length)
-  : os.hostname().replace(/[^a-zA-Z0-9_-]/g, "_");
+  : getMachineName();
 
 let cmd = "npx --yes ccusage@latest daily --json";
 if (sinceFlag) cmd += ` ${sinceFlag}`;


### PR DESCRIPTION
## Summary
- Cross-platform hardware machine ID as default identifier (no more hostname collisions)
- `update` fetches other machines' data files from GitHub before merging

## Machine ID by platform
| OS | Source | Example |
|---|---|---|
| macOS | Serial Number (`ioreg`) | `T4MV6DCPVD` |
| Linux | `/etc/machine-id` (first 12 chars) | `a1b2c3d4e5f6` |
| Windows | WMI UUID (first 12 chars) | `4C4C4544004` |
| fallback | hostname | `seunggabi` |

## Test plan
- [ ] Run `update` on macOS without `--name` → uses Serial Number as filename
- [ ] Run `update` on Linux without `--name` → uses machine-id as filename
- [ ] Multiple MacBooks generate different `data-*.json` files without collision
- [ ] Second machine fetches first machine's file before merging

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)