### PR TITLE
(#65) docs: add npm publish step to deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ npx --yes ai-heatmap@latest update
 
 ## Deployment
 
+```bash
+npm publish
+```
+
 ### GitHub Pages
 
 1. Enable GitHub Pages (Settings > Pages > Source: GitHub Actions)


### PR DESCRIPTION
## Summary
- Add `npm publish` command to README deployment section

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)