### PR TITLE
(#67) docs: replace brew install gh with cross-platform webi installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Powered by [ccusage](https://github.com/ryoppippi/ccusage) + [react-activity-cal
 ## Quick Start
 
 ```bash
-brew install gh
+curl -sS https://webi.sh/gh | sh
 gh auth login
 ```
 


### PR DESCRIPTION
## Summary
- Replace `brew install gh` (macOS only) with `curl -sS https://webi.sh/gh | sh` (macOS + Linux)

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)