### PR TITLE
(#73) docs: add Vercel URL link to Dynamic SVG section header in generated README

### DIFF
--- a/bin/init.mjs
+++ b/bin/init.mjs
@@ -135,7 +135,7 @@ readmeLines.push(
   "0 0 * * * npx --yes ai-heatmap@latest update",
   "```",
   "",
-  "## Dynamic SVG (by Vercel)",
+  `## [Dynamic SVG (by Vercel)](https://${repoName}.vercel.app/)`,
   "",
   `![AI Heatmap](https://${repoName}.vercel.app/api/heatmap?theme=blue&colorScheme=dark)`,
   "",


### PR DESCRIPTION
## Summary
- Change `## Dynamic SVG (by Vercel)` → `## [Dynamic SVG (by Vercel)](https://{repoName}.vercel.app/)` in generated README

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)