### PR TITLE
(#75) feat: add --merge-only and --dir flags to generate script

### DIFF
--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -33,20 +33,11 @@ const args = process.argv.slice(2);
 const sinceFlag = args.find((a) => a.startsWith("--since"));
 const untilFlag = args.find((a) => a.startsWith("--until"));
 const nameFlag = args.find((a) => a.startsWith("--name="));
+const dirFlag = args.find((a) => a.startsWith("--dir="));
+const mergeOnly = args.includes("--merge-only");
 const machineName = nameFlag
   ? nameFlag.slice("--name=".length)
   : getMachineName();
-
-let cmd = "npx --yes ccusage@latest daily --json";
-if (sinceFlag) cmd += ` ${sinceFlag}`;
-if (untilFlag) cmd += ` ${untilFlag}`;
-
-console.log(`Running: ${cmd}`);
-const raw = execSync(cmd, { encoding: "utf-8", timeout: 300000 });
-const { daily } = JSON.parse(raw);
-
-const costs = daily.map((d) => d.totalCost);
-const maxCost = Math.max(...costs);
 
 function toLevel(cost, max) {
   if (cost === 0 || max === 0) return 0;
@@ -57,52 +48,67 @@ function toLevel(cost, max) {
   return 4;
 }
 
-// Build a map of existing data
-const dataMap = new Map(daily.map((d) => [d.date, d]));
-
-// Fill 365 days (from today back 364 days)
-const today = new Date();
-const activities = [];
-for (let i = 364; i >= 0; i--) {
-  const d = new Date(today);
-  d.setDate(d.getDate() - i);
-  const date = d.toISOString().slice(0, 10);
-  const entry = dataMap.get(date);
-  if (entry) {
-    const cacheReadTokens = entry.cacheReadTokens ?? 0;
-    const cacheCreationTokens = entry.cacheCreationTokens ?? 0;
-    const cacheTotal = cacheCreationTokens + cacheReadTokens;
-    const cacheHitRate = cacheTotal > 0
-      ? Math.round((cacheReadTokens / cacheTotal) * 100)
-      : 0;
-    activities.push({
-      date,
-      count: Math.round(entry.totalCost * 100) / 100,
-      level: toLevel(entry.totalCost, maxCost),
-      inputTokens: entry.inputTokens,
-      outputTokens: entry.outputTokens,
-      totalTokens: entry.totalTokens,
-      cacheReadTokens,
-      cacheCreationTokens,
-      cacheHitRate,
-      modelsUsed: entry.modelsUsed,
-      modelBreakdowns: entry.modelBreakdowns.map((m) => ({
-        model: m.modelName,
-        cost: Math.round(m.cost * 100) / 100,
-      })),
-    });
-  } else {
-    activities.push({ date, count: 0, level: 0 });
-  }
-}
-
-const outDir = resolve(root, "public");
+const outDir = dirFlag
+  ? resolve(dirFlag.slice("--dir=".length))
+  : resolve(root, "public");
 mkdirSync(outDir, { recursive: true });
 
-// 1. 컴퓨터별 개별 파일 저장
-const machineFile = resolve(outDir, `data-${machineName}.json`);
-writeFileSync(machineFile, JSON.stringify(activities, null, 2));
-console.log(`Generated ${machineFile} (${activities.length} days)`);
+if (!mergeOnly) {
+  let cmd = "npx --yes ccusage@latest daily --json";
+  if (sinceFlag) cmd += ` ${sinceFlag}`;
+  if (untilFlag) cmd += ` ${untilFlag}`;
+
+  console.log(`Running: ${cmd}`);
+  const raw = execSync(cmd, { encoding: "utf-8", timeout: 300000 });
+  const { daily } = JSON.parse(raw);
+
+  const costs = daily.map((d) => d.totalCost);
+  const maxCost = Math.max(...costs);
+
+  // Build a map of existing data
+  const dataMap = new Map(daily.map((d) => [d.date, d]));
+
+  // Fill 365 days (from today back 364 days)
+  const today = new Date();
+  const activities = [];
+  for (let i = 364; i >= 0; i--) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    const date = d.toISOString().slice(0, 10);
+    const entry = dataMap.get(date);
+    if (entry) {
+      const cacheReadTokens = entry.cacheReadTokens ?? 0;
+      const cacheCreationTokens = entry.cacheCreationTokens ?? 0;
+      const cacheTotal = cacheCreationTokens + cacheReadTokens;
+      const cacheHitRate = cacheTotal > 0
+        ? Math.round((cacheReadTokens / cacheTotal) * 100)
+        : 0;
+      activities.push({
+        date,
+        count: Math.round(entry.totalCost * 100) / 100,
+        level: toLevel(entry.totalCost, maxCost),
+        inputTokens: entry.inputTokens,
+        outputTokens: entry.outputTokens,
+        totalTokens: entry.totalTokens,
+        cacheReadTokens,
+        cacheCreationTokens,
+        cacheHitRate,
+        modelsUsed: entry.modelsUsed,
+        modelBreakdowns: entry.modelBreakdowns.map((m) => ({
+          model: m.modelName,
+          cost: Math.round(m.cost * 100) / 100,
+        })),
+      });
+    } else {
+      activities.push({ date, count: 0, level: 0 });
+    }
+  }
+
+  // 1. 컴퓨터별 개별 파일 저장
+  const machineFile = resolve(outDir, `data-${machineName}.json`);
+  writeFileSync(machineFile, JSON.stringify(activities, null, 2));
+  console.log(`Generated ${machineFile} (${activities.length} days)`);
+}
 
 // 2. 모든 data-{name}.json 파일을 읽어서 합산
 const dataFiles = readdirSync(outDir)


### PR DESCRIPTION
## Summary

- Add `--merge-only` flag: skip ccusage execution, only merge existing `data-*.json` files
- Add `--dir=<path>` flag: specify custom output directory for data files

## Use Case

```bash
node scripts/generate.mjs --merge-only --dir=/path/to/public
```

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)