### PR TITLE
(#79) fix: fetch other machines' data files correctly and use local timezone dates

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -136,7 +136,12 @@ switch (command) {
       for (const file of files) {
         // 현재 컴퓨터 파일은 generate에서 새로 생성하므로 건너뜀
         if (file.name === `data-${machineName}.json`) continue;
-        const decoded = Buffer.from(file.content.replace(/\n/g, ""), "base64").toString("utf-8");
+        // 디렉토리 목록 API는 content를 포함하지 않으므로 파일별로 개별 fetch
+        const content = execSync(
+          `gh api repos/${repo}/contents/${file.path} --jq .content`,
+          { encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] },
+        ).trim();
+        const decoded = Buffer.from(content.replace(/\n/g, ""), "base64").toString("utf-8");
         writeFileSync(resolve(outDir, file.name), decoded);
         console.log(`  Fetched ${file.name}`);
       }

--- a/scripts/generate.mjs
+++ b/scripts/generate.mjs
@@ -74,7 +74,7 @@ if (!mergeOnly) {
   for (let i = 364; i >= 0; i--) {
     const d = new Date(today);
     d.setDate(d.getDate() - i);
-    const date = d.toISOString().slice(0, 10);
+    const date = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
     const entry = dataMap.get(date);
     if (entry) {
       const cacheReadTokens = entry.cacheReadTokens ?? 0;


### PR DESCRIPTION
## Summary
- Fix directory listing API not including `content` field — now fetches each file individually
- Fix date off-by-one in non-UTC timezones — use local date instead of `toISOString()`

Closes #79