### PR TITLE
(#83) docs: add cache clear to cron update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ For automated updates, use a local cron job or macOS LaunchAgent:
 CLAUDE_CODE_OAUTH_TOKEN=sk-ant-xxx
 GH_TOKEN=ghp_xxx
 
-0 0 * * * npx --yes ai-heatmap@latest update
+0 0 * * * npx clear-npx-cache && npx --yes ai-heatmap@latest update
 ```
 
 > **`npx: not found`?** cron uses a minimal PATH. Fix with:


### PR DESCRIPTION
Always prepend `npx clear-npx-cache` before the update command in cron to ensure the latest published version is always used.

Closes #83