### PR TITLE
(#85) docs: add cache clear to cron example in init.mjs generated README

### DIFF
--- a/bin/init.mjs
+++ b/bin/init.mjs
@@ -132,7 +132,7 @@ readmeLines.push(
   "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-xxx",
   "GH_TOKEN=ghp_xxx",
   "",
-  "0 0 * * * npx --yes ai-heatmap@latest update",
+  "0 0 * * * npx clear-npx-cache && npx --yes ai-heatmap@latest update",
   "```",
   "",
   `## [Dynamic SVG (by Vercel)](https://${repoName}.vercel.app/)`,


### PR DESCRIPTION
Update the cron example in the README generated by `ai-heatmap init` to prepend `npx clear-npx-cache` before the update command.

Closes #85