### PR TITLE
(#91) chore: sync package-lock.json version to 1.17.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-heatmap",
-  "version": "1.14.4",
+  "version": "1.17.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-heatmap",
-      "version": "1.14.4",
+      "version": "1.17.6",
       "license": "MIT",
       "dependencies": {
         "react": "^19.2.4",


### PR DESCRIPTION
## Summary
- Sync `package-lock.json` version field from `1.14.4` to `1.17.6` to match current `package.json`

## Test plan
- [ ] Verify `package-lock.json` version matches `package.json` version

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)