### PR TITLE
(#101) fix: replace invalid jq escape \.json with [.]json

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -130,7 +130,7 @@ switch (command) {
     let remoteFiles = [];
     try {
       const raw = execSync(
-        `gh api repos/${repo}/contents/public --jq '[.[] | select(.name | test("^data-.+\\.json$"))]'`,
+        `gh api repos/${repo}/contents/public --jq '[.[] | select(.name | test("^data-.+[.]json$"))]'`,
         { encoding: "utf-8", stdio: ["pipe", "pipe", "ignore"] },
       );
       remoteFiles = JSON.parse(raw);


### PR DESCRIPTION
## Summary
- Fix: jq expression `\\.json` in JS template literal becomes `\.json` in the shell string
- jq rejects `\.` as an invalid escape sequence → directory listing fails silently → other machines' files not fetched
- Fix: use `[.]json` instead (character class matching literal dot)

## Root Cause
```js
// BEFORE — \\.  in JS template → \.  in shell → invalid jq escape
`--jq '[.[] | select(.name | test("^data-.+\\.json$"))]'`

// AFTER — [.] matches literal dot in jq regex
`--jq '[.[] | select(.name | test("^data-.+[.]json$"))]'`
```

## Test plan
- [ ] Run `npx ai-heatmap update` with multiple machine files in remote repo
- [ ] Confirm both `data-*.json` files are fetched and merged correctly

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)